### PR TITLE
fix: /submit silent failure + real cost tracking in 費用明細

### DIFF
--- a/graph/nodes/debater.py
+++ b/graph/nodes/debater.py
@@ -18,6 +18,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 
 from graph.progress import publish_progress
 from graph.state import PantheonState
+from llm.cost_tracker import merge_usage
 from llm.provider import LLMProvider, PHASE_MODEL_ROLES
 from llm.quota_fallback import ProviderQuotaExhausted, ainvoke_with_fallback
 from utils.timeout import with_timeout, TimeoutError as PantheonTimeoutError
@@ -66,6 +67,7 @@ async def debate_node(state: PantheonState) -> PantheonState:
 
     history_snapshot = list(state.get("debate_history", []))
     new_entries: list[dict] = []
+    cost_summary: dict = dict(state.get("cost_summary") or {})
 
     session_id: str = state.get("session_id", "")
 
@@ -82,7 +84,17 @@ async def debate_node(state: PantheonState) -> PantheonState:
                 seconds=float(DEBATE_TIMEOUT_SECONDS),
                 label=f"debater:{model_key}",
             )
+            usage = entry.pop("usage", {})
             new_entries.append(entry)
+            if usage.get("input_tokens") or usage.get("output_tokens"):
+                cost_summary = merge_usage(
+                    cost_summary,
+                    model_key=entry["model"],
+                    litellm_model=usage["litellm_model"],
+                    phase="debate",
+                    input_tokens=usage["input_tokens"],
+                    output_tokens=usage["output_tokens"],
+                )
             logger.info("Debate round %d: %s responded (%d chars)",
                         current_round, model_key, len(entry["content"]))
             await publish_progress(session_id, {
@@ -176,6 +188,7 @@ async def debate_node(state: PantheonState) -> PantheonState:
         **state,
         "debate_history": history_snapshot + new_entries,
         "debate_round": current_round,
+        "cost_summary": cost_summary,
         "phase": "debate",
     }
 
@@ -205,7 +218,7 @@ async def _get_model_statement(
         )),
     ]
 
-    actual_model, content = await ainvoke_with_fallback(
+    actual_model, content, usage = await ainvoke_with_fallback(
         provider=provider,
         model_key=model_key,
         messages=messages,
@@ -219,6 +232,7 @@ async def _get_model_statement(
         "model_requested": model_key if actual_model != model_key else None,
         "content": content,
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "usage": usage,
     }
 
 

--- a/graph/nodes/researcher.py
+++ b/graph/nodes/researcher.py
@@ -16,6 +16,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 
 from graph.progress import publish_progress
 from graph.state import PantheonState
+from llm.cost_tracker import merge_usage
 from llm.provider import PHASE_MODEL_ROLES, LLMProvider
 from llm.quota_fallback import ProviderQuotaExhausted, ainvoke_with_fallback
 from utils.logging_config import get_logger
@@ -63,17 +64,30 @@ async def researcher_node(state: PantheonState) -> PantheonState:
         for model_key in researcher_models
     ]
 
-    results_list: list[tuple[str, str]] = await asyncio.gather(*tasks)
-    research_results: dict[str, str] = dict(results_list)
+    results_list: list[tuple[str, str, dict]] = await asyncio.gather(*tasks)
+    research_results: dict[str, str] = {model_key: text for model_key, text, _ in results_list}
+
+    cost_summary: dict = dict(state.get("cost_summary") or {})
+    for model_key, _text, usage in results_list:
+        if usage.get("input_tokens") or usage.get("output_tokens"):
+            cost_summary = merge_usage(
+                cost_summary,
+                model_key=model_key,
+                litellm_model=usage["litellm_model"],
+                phase="research",
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+            )
 
     logger.info(
         "Research phase complete: %d models responded",
-        sum(1 for _, v in results_list if not v.startswith("[ERROR")),
+        sum(1 for _, v, _ in results_list if not v.startswith("[ERROR")),
     )
 
     return {
         **state,
         "research_results": research_results,
+        "cost_summary": cost_summary,
         "phase": "debate",
     }
 
@@ -85,12 +99,13 @@ async def _research_with_timeout(
     task: str,
     timeout: int,
     session_id: str = "",
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Call a single researcher model, enforcing a timeout.
 
     Returns:
-        (model_key, research_text) — on failure, research_text is an error
-        placeholder so downstream nodes always have an entry for every model.
+        (model_key, research_text, usage) — on failure, research_text is an
+        error placeholder and usage is empty so downstream nodes always have an
+        entry for every model.
     """
     from datetime import datetime, timezone  # local import to avoid circular at module level
 
@@ -105,32 +120,33 @@ async def _research_with_timeout(
             "timestamp": datetime.now(timezone.utc).isoformat(),
         })
 
+    _empty_usage: dict = {"input_tokens": 0, "output_tokens": 0, "litellm_model": ""}
     try:
-        result = await with_timeout(
+        result, usage = await with_timeout(
             _get_research(provider=provider, model_key=model_key, task=task),
             seconds=float(timeout),
             label=f"researcher:{model_key}",
         )
         logger.info("researcher_done", model=model_key, chars=len(result))
         await _publish(result, skipped=False)
-        return model_key, result
+        return model_key, result, usage
     except PantheonTimeoutError:
         logger.warning("researcher_timeout", model=model_key, timeout_s=timeout)
         content = f"⚠️ {model_key} timed out after {timeout}s — skipped."
         await _publish(content, skipped=True)
-        return model_key, content
+        return model_key, content, _empty_usage
     except ProviderQuotaExhausted as exc:
         # Clean, user-friendly message — the str() of the exception is already
         # formatted for the UI by quota_fallback.py
         logger.warning("researcher_quota_exhausted", model=model_key, detail=str(exc))
         content = str(exc)
         await _publish(content, skipped=True)
-        return model_key, content
+        return model_key, content, _empty_usage
     except Exception as exc:
         logger.warning("researcher_error", model=model_key, error=str(exc))
         content = f"⚠️ {model_key} encountered an error and was skipped."
         await _publish(content, skipped=True)
-        return model_key, content
+        return model_key, content, _empty_usage
 
 
 async def _get_research(
@@ -138,8 +154,8 @@ async def _get_research(
     provider: LLMProvider,
     model_key: str,
     task: str,
-) -> str:
-    """Invoke the model and return its research text.
+) -> tuple[str, dict]:
+    """Invoke the model and return (research_text, usage).
 
     Automatically falls back to cheaper models within the same provider when a
     quota / rate-limit error (429) is encountered.
@@ -154,7 +170,7 @@ async def _get_research(
         ),
     ]
 
-    actual_model, content = await ainvoke_with_fallback(
+    actual_model, content, usage = await ainvoke_with_fallback(
         provider=provider,
         model_key=model_key,
         messages=messages,
@@ -168,7 +184,7 @@ async def _get_research(
             model_key,
         )
 
-    return content
+    return content, usage
 
 
 def _resolve_researcher_models(provider: LLMProvider, state: PantheonState) -> list[str]:

--- a/graph/nodes/synthesizer.py
+++ b/graph/nodes/synthesizer.py
@@ -14,6 +14,7 @@ import os
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from graph.state import PantheonState
+from llm.cost_tracker import merge_usage
 from llm.provider import PHASE_MODEL_ROLES, LLMProvider
 from llm.quota_fallback import ainvoke_with_fallback
 
@@ -96,14 +97,33 @@ def _format_cost(cost_summary: dict) -> str:
     if not cost_summary:
         return "N/A"
     lines: list[str] = []
-    if "total_cost_usd" in cost_summary:
-        lines.append(f"- **Total cost**: ${cost_summary['total_cost_usd']:.4f}")
+    total_usd = cost_summary.get("total_cost_usd", 0.0)
+    total_in = cost_summary.get("total_input_tokens", 0)
+    total_out = cost_summary.get("total_output_tokens", 0)
+    lines.append(
+        f"- 總費用：${total_usd:.4f} USD"
+        f"（輸入 {total_in:,} tokens，輸出 {total_out:,} tokens）"
+    )
     if "by_model" in cost_summary:
-        for model, cost in cost_summary["by_model"].items():
-            lines.append(f"  - {model}: ${cost:.4f}")
+        lines.append("\n各模型明細：")
+        for model, data in cost_summary["by_model"].items():
+            if isinstance(data, dict):
+                lines.append(
+                    f"  - {model}：${data.get('cost_usd', 0):.4f}"
+                    f"（in {data.get('input_tokens', 0):,} / out {data.get('output_tokens', 0):,}）"
+                )
+            else:
+                lines.append(f"  - {model}：${data:.4f}")
     if "by_phase" in cost_summary:
-        for phase, cost in cost_summary["by_phase"].items():
-            lines.append(f"  - Phase {phase}: ${cost:.4f}")
+        lines.append("\n各階段費用：")
+        for phase, data in cost_summary["by_phase"].items():
+            if isinstance(data, dict):
+                lines.append(
+                    f"  - {phase}：${data.get('cost_usd', 0):.4f}"
+                    f"（in {data.get('input_tokens', 0):,} / out {data.get('output_tokens', 0):,}）"
+                )
+            else:
+                lines.append(f"  - {phase}：${data:.4f}")
     return "\n".join(lines) if lines else "N/A"
 
 
@@ -139,9 +159,11 @@ async def synthesizer_node(state: PantheonState) -> PantheonState:
         "請現在撰寫最終報告。"
     )
 
+    cost_summary: dict = dict(state.get("cost_summary") or {})
+
     final_report: str
     try:
-        actual_model, content = await ainvoke_with_fallback(
+        actual_model, content, usage = await ainvoke_with_fallback(
             provider=provider,
             model_key=pm_model_key,
             messages=[
@@ -152,6 +174,15 @@ async def synthesizer_node(state: PantheonState) -> PantheonState:
             # Claude Haiku / GPT-4o-mini if the primary provider is exhausted.
             allow_cross_provider=True,
         )
+        if usage.get("input_tokens") or usage.get("output_tokens"):
+            cost_summary = merge_usage(
+                cost_summary,
+                model_key=actual_model,
+                litellm_model=usage["litellm_model"],
+                phase="synthesis",
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+            )
         final_report = content
         logger.info(
             "Synthesizer complete: %d chars in final report (model=%s)",
@@ -171,5 +202,6 @@ async def synthesizer_node(state: PantheonState) -> PantheonState:
     return {
         **state,
         "final_report": final_report,
+        "cost_summary": cost_summary,
         "phase": "complete",
     }

--- a/graph/nodes/voter.py
+++ b/graph/nodes/voter.py
@@ -17,6 +17,7 @@ from typing import List
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from graph.state import PantheonState
+from llm.cost_tracker import merge_usage
 from llm.provider import PHASE_MODEL_ROLES, LLMProvider
 from llm.quota_fallback import ProviderQuotaExhausted, ainvoke_with_fallback
 
@@ -71,8 +72,20 @@ async def voter_node(state: PantheonState) -> PantheonState:
         for model_key in voter_models
     ]
 
-    results: list[tuple[str, str]] = await asyncio.gather(*tasks)
-    votes: dict[str, str] = {model: vote for model, vote in results}
+    results: list[tuple[str, str, dict]] = await asyncio.gather(*tasks)
+    votes: dict[str, str] = {model: vote for model, vote, _ in results}
+
+    cost_summary: dict = dict(state.get("cost_summary") or {})
+    for model_key, _vote, usage in results:
+        if usage.get("input_tokens") or usage.get("output_tokens"):
+            cost_summary = merge_usage(
+                cost_summary,
+                model_key=model_key,
+                litellm_model=usage["litellm_model"],
+                phase="voting",
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+            )
 
     consensus = _calculate_consensus(votes)
     logger.info(
@@ -85,6 +98,7 @@ async def voter_node(state: PantheonState) -> PantheonState:
         **state,
         "votes": votes,
         "consensus": consensus,
+        "cost_summary": cost_summary,
         "phase": "synthesis",
     }
 
@@ -96,14 +110,15 @@ async def _vote_with_timeout(
     task: str,
     debate_transcript: str,
     timeout: int,
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Cast one vote with a timeout guard.
 
     Returns:
-        (model_key, vote_label) — placeholder on failure.
+        (model_key, vote_label, usage) — placeholder on failure.
     """
+    _empty_usage: dict = {"input_tokens": 0, "output_tokens": 0, "litellm_model": ""}
     try:
-        vote = await asyncio.wait_for(
+        vote, usage = await asyncio.wait_for(
             _cast_vote(
                 provider=provider,
                 model_key=model_key,
@@ -113,16 +128,16 @@ async def _vote_with_timeout(
             timeout=float(timeout),
         )
         logger.info("Voter %s: %s", model_key, vote)
-        return model_key, vote
+        return model_key, vote, usage
     except asyncio.TimeoutError:
         logger.warning("Voter %s timed out after %ds", model_key, timeout)
-        return model_key, "[TIMEOUT]"
+        return model_key, "[TIMEOUT]", _empty_usage
     except ProviderQuotaExhausted:
         logger.warning("Voter %s: quota exhausted — skipping vote", model_key)
-        return model_key, "[QUOTA]"
+        return model_key, "[QUOTA]", _empty_usage
     except Exception as exc:
         logger.warning("Voter %s failed: %s", model_key, exc)
-        return model_key, "[ERROR]"
+        return model_key, "[ERROR]", _empty_usage
 
 
 async def _cast_vote(
@@ -131,8 +146,8 @@ async def _cast_vote(
     model_key: str,
     task: str,
     debate_transcript: str,
-) -> str:
-    """Invoke a single model to cast its vote and return the extracted label."""
+) -> tuple[str, dict]:
+    """Invoke a single model to cast its vote and return (vote_label, usage)."""
     messages = [
         SystemMessage(content=_SYSTEM_PROMPT),
         HumanMessage(
@@ -144,7 +159,7 @@ async def _cast_vote(
         ),
     ]
 
-    _actual_model, raw = await ainvoke_with_fallback(
+    _actual_model, raw, usage = await ainvoke_with_fallback(
         provider=provider,
         model_key=model_key,
         messages=messages,
@@ -153,14 +168,14 @@ async def _cast_vote(
     # Extract the VOTE: label from the response
     for line in raw.splitlines():
         if line.strip().upper().startswith("VOTE:"):
-            return line.split(":", 1)[1].strip()
+            return line.split(":", 1)[1].strip(), usage
 
     # Fallback: return first non-empty line
     for line in raw.splitlines():
         if line.strip():
-            return line.strip()[:80]
+            return line.strip()[:80], usage
 
-    return raw.strip()[:80]
+    return raw.strip()[:80], usage
 
 
 def _calculate_consensus(votes: dict[str, str]) -> str | None:

--- a/llm/cost_tracker.py
+++ b/llm/cost_tracker.py
@@ -237,3 +237,61 @@ def _calculate_cost(model: str, tokens_in: int, tokens_out: int) -> float:
     except Exception:
         logger.debug("Cost calculation not available for model=%s, returning 0", model)
         return 0.0
+
+
+def merge_usage(
+    existing: dict,
+    *,
+    model_key: str,
+    litellm_model: str,
+    phase: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> dict:
+    """Merge one LLM call's usage into the accumulated cost_summary dict.
+
+    Pure function — returns a new dict, never mutates ``existing``.
+    Designed for the LangGraph last-write-wins state pattern: each node calls
+    this once per LLM call and returns the updated dict as part of its state.
+
+    Structure of the returned dict::
+
+        {
+            "by_model": {
+                "claude-sonnet": {"input_tokens": 1500, "output_tokens": 800, "cost_usd": 0.016},
+                ...
+            },
+            "by_phase": {
+                "research": {"input_tokens": 4500, "output_tokens": 2400, "cost_usd": 0.048},
+                ...
+            },
+            "total_input_tokens": 6000,
+            "total_output_tokens": 3200,
+            "total_cost_usd": 0.064,
+        }
+    """
+    cost = _calculate_cost(litellm_model, input_tokens, output_tokens)
+
+    result = dict(existing) if existing else {}
+
+    by_model: dict = {k: dict(v) for k, v in result.get("by_model", {}).items()}
+    entry = dict(by_model.get(model_key, {}))
+    entry["input_tokens"] = entry.get("input_tokens", 0) + input_tokens
+    entry["output_tokens"] = entry.get("output_tokens", 0) + output_tokens
+    entry["cost_usd"] = round(entry.get("cost_usd", 0.0) + cost, 6)
+    by_model[model_key] = entry
+
+    by_phase: dict = {k: dict(v) for k, v in result.get("by_phase", {}).items()}
+    phase_entry = dict(by_phase.get(phase, {}))
+    phase_entry["input_tokens"] = phase_entry.get("input_tokens", 0) + input_tokens
+    phase_entry["output_tokens"] = phase_entry.get("output_tokens", 0) + output_tokens
+    phase_entry["cost_usd"] = round(phase_entry.get("cost_usd", 0.0) + cost, 6)
+    by_phase[phase] = phase_entry
+
+    result["by_model"] = by_model
+    result["by_phase"] = by_phase
+    result["total_input_tokens"] = result.get("total_input_tokens", 0) + input_tokens
+    result["total_output_tokens"] = result.get("total_output_tokens", 0) + output_tokens
+    result["total_cost_usd"] = round(result.get("total_cost_usd", 0.0) + cost, 6)
+
+    return result

--- a/llm/quota_fallback.py
+++ b/llm/quota_fallback.py
@@ -18,6 +18,7 @@ from typing import Any, Sequence
 
 from langchain_core.messages import BaseMessage
 
+from llm.cost_tracker import _extract_token_counts
 from utils.message_utils import sanitize_messages
 
 logger = logging.getLogger(__name__)
@@ -154,7 +155,7 @@ async def ainvoke_with_fallback(
     model_key: str,
     messages: Sequence[BaseMessage],
     allow_cross_provider: bool = False,
-) -> tuple[str, str]:
+) -> tuple[str, str, dict]:
     """Invoke a model, falling back on quota errors.
 
     Args:
@@ -167,8 +168,9 @@ async def ainvoke_with_fallback(
             output (synthesizer).
 
     Returns:
-        ``(actual_model_key, content)`` — *actual_model_key* may differ from
-        *model_key* when a fallback was used.
+        ``(actual_model_key, content, usage)`` — *actual_model_key* may differ
+        from *model_key* when a fallback was used.  *usage* is a dict with
+        ``{"input_tokens": int, "output_tokens": int, "litellm_model": str}``.
 
     Raises:
         :class:`ProviderQuotaExhausted`: When every candidate is
@@ -187,13 +189,20 @@ async def ainvoke_with_fallback(
             content: str = (
                 response.content if hasattr(response, "content") else str(response)
             )
+            input_tokens, output_tokens = _extract_token_counts(response)
+            litellm_model: str = provider.get_model_config(candidate).litellm_model
+            usage = {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "litellm_model": litellm_model,
+            }
             if candidate != model_key:
                 logger.warning(
                     "quota_fallback: %s → %s (quota exceeded on primary)",
                     model_key,
                     candidate,
                 )
-            return candidate, content.strip()
+            return candidate, content.strip(), usage
 
         except Exception as exc:
             if _is_quota_error(exc):
@@ -229,12 +238,19 @@ async def ainvoke_with_fallback(
                 content = (
                     response.content if hasattr(response, "content") else str(response)
                 )
+                input_tokens, output_tokens = _extract_token_counts(response)
+                litellm_model = provider.get_model_config(candidate).litellm_model
+                usage = {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "litellm_model": litellm_model,
+                }
                 logger.warning(
                     "quota_fallback: all %s models exhausted — used cross-provider %s",
                     model_key,
                     candidate,
                 )
-                return candidate, content.strip()
+                return candidate, content.strip(), usage
             except Exception as exc:
                 if _is_quota_error(exc):
                     logger.warning(

--- a/telegram_adapter/telegram_bot.py
+++ b/telegram_adapter/telegram_bot.py
@@ -221,6 +221,7 @@ class TelegramBot:
         app.add_handlers([
             CommandHandler("start", self.handle_start),
             CommandHandler("help", self.handle_help),
+            CommandHandler("ping", self.handle_ping),
             CommandHandler("reset", self.handle_reset),
             CommandHandler("submit", self.handle_submit),
             CommandHandler("status", self.handle_status),
@@ -284,6 +285,20 @@ class TelegramBot:
         if agent_manager:
             await agent_manager.shutdown()
             logger.info("Agent manager shut down")
+
+    async def handle_ping(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """/ping — Check bot + Redis health."""
+        redis_ok = False
+        try:
+            if self.redis:
+                await self.redis.ping()
+                redis_ok = True
+        except Exception:
+            pass
+        redis_status = "✅ 正常" if redis_ok else "❌ 離線"
+        await update.message.reply_text(
+            f"🤖 Bot: ✅ 運行中\n🗄️ Redis: {redis_status}"
+        )
 
     async def handle_start(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle /start command"""
@@ -355,20 +370,27 @@ class TelegramBot:
 
         session_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
-        await self.redis.hset(
-            _session_key(session_id),
-            mapping={
-                "session_id": session_id,
-                "status": "running",
-                "phase": "routing",
-                "task": task,
-                "user_id": user_id,
-                "final_report": "",
-                "cost_summary": "{}",
-                "created_at": now,
-            },
-        )
-        await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        try:
+            await self.redis.hset(
+                _session_key(session_id),
+                mapping={
+                    "session_id": session_id,
+                    "status": "running",
+                    "phase": "routing",
+                    "task": task,
+                    "user_id": user_id,
+                    "final_report": "",
+                    "cost_summary": "{}",
+                    "created_at": now,
+                },
+            )
+            await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        except Exception as exc:
+            logger.error("handle_submit: Redis error for session %s: %s", session_id, exc)
+            await update.message.reply_text(
+                "❌ 無法建立工作階段（Redis 連線失敗），請稍後再試。"
+            )
+            return
 
         # HTML mode + html.escape() so URLs/underscores/etc. in `task` don't
         # break the parser (legacy Markdown treats _ as italic → entity error).
@@ -640,17 +662,24 @@ class TelegramBot:
 
         session_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
-        await self.redis.hset(_session_key(session_id), mapping={
-            "session_id": session_id,
-            "user_id": user_id,
-            "chat_id": str(chat_id),
-            "task": task,
-            "status": "running",
-            "phase": "routing",
-            "created_at": now,
-            "source": "photo",
-        })
-        await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        try:
+            await self.redis.hset(_session_key(session_id), mapping={
+                "session_id": session_id,
+                "user_id": user_id,
+                "chat_id": str(chat_id),
+                "task": task,
+                "status": "running",
+                "phase": "routing",
+                "created_at": now,
+                "source": "photo",
+            })
+            await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        except Exception as exc:
+            logger.error("handle_photo: Redis error for session %s: %s", session_id, exc)
+            await update.message.reply_text(
+                "❌ 無法建立工作階段（Redis 連線失敗），請稍後再試。"
+            )
+            return
 
         asyncio.create_task(_run_session(session_id, task, user_id, self.redis, []))
         asyncio.create_task(self._watch_session(session_id, chat_id, context.application.bot))
@@ -727,21 +756,28 @@ class TelegramBot:
 
         session_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
-        await self.redis.hset(
-            _session_key(session_id),
-            mapping={
-                "session_id": session_id,
-                "status": "running",
-                "phase": "routing",
-                "task": task,
-                "user_id": user_id,
-                "final_report": "",
-                "cost_summary": "{}",
-                "created_at": now,
-                "source": "document",
-            },
-        )
-        await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        try:
+            await self.redis.hset(
+                _session_key(session_id),
+                mapping={
+                    "session_id": session_id,
+                    "status": "running",
+                    "phase": "routing",
+                    "task": task,
+                    "user_id": user_id,
+                    "final_report": "",
+                    "cost_summary": "{}",
+                    "created_at": now,
+                    "source": "document",
+                },
+            )
+            await self.redis.expire(_session_key(session_id), SESSION_TTL)
+        except Exception as exc:
+            logger.error("handle_document: Redis error for session %s: %s", session_id, exc)
+            await update.message.reply_text(
+                "❌ 無法建立工作階段（Redis 連線失敗），請稍後再試。"
+            )
+            return
 
         asyncio.create_task(_run_session(session_id, task, user_id, self.redis, []))
         asyncio.create_task(self._watch_session(session_id, chat_id, context.application.bot))


### PR DESCRIPTION
Two bugs fixed:

1. handle_submit/photo/document silent Redis failure:
   Redis ops (hset/expire) weren't wrapped in try/except. A runtime
   Redis disconnect after startup caused the handler to throw an
   unhandled exception — Telegram's error handler logs it but sends
   nothing to the user, so /submit produced total silence.
   Now catches the exception and replies with an explicit error msg.
   Added /ping command for quick bot + Redis health check.

2. 費用明細 always showed 無資料:
   ainvoke_with_fallback discarded usage_metadata from LangChain
   responses and returned only (model, content). cost_summary in state
   was never populated.
   - ainvoke_with_fallback now returns (model, content, usage) where
     usage = {input_tokens, output_tokens, litellm_model}
   - Added merge_usage() to llm/cost_tracker.py — pure function that
     accumulates per-model + per-phase token counts and USD cost into
     the state dict (LangGraph last-write-wins pattern)
   - All nodes (researcher, debater, voter, synthesizer) now call
     merge_usage and return updated cost_summary in state
   - _format_cost() in synthesizer updated for new dict structure

https://claude.ai/code/session_0195y1fcLTEX7T3k5A2sLdYe