### PR TITLE
fix(delete): S1-DEL-1 — fix 3 bugs in clear_user_data (closes #25)

### DIFF
--- a/db/user_data.py
+++ b/db/user_data.py
@@ -2,98 +2,150 @@
 User data management utilities.
 """
 
+import os
 import logging
-from typing import Optional
-from redis.asyncio import Redis
-from psycopg_pool import AsyncConnectionPool
-from langgraph.store.postgres import AsyncPostgresStore
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+    from psycopg_pool import AsyncConnectionPool
+    from langgraph.store.postgres import AsyncPostgresStore
 
 logger = logging.getLogger(__name__)
 
+
 async def clear_user_data(
-    user_id: str, 
-    redis: Redis, 
-    pool: AsyncConnectionPool, 
-    store: AsyncPostgresStore
+    user_id: str,
+    redis,   # Redis
+    pool,    # AsyncConnectionPool
+    store,   # AsyncPostgresStore
 ) -> None:
-    """Clear all data for a user to start fresh
-    
-    Args:
-        user_id: User identifier
-        redis: Redis connection
-        pool: PostgreSQL connection pool
-        store: Vector store (optional)
+    """Clear all data for a user to start fresh.
+
+    Deletes, in order:
+      1. Redis keys matching ``user:<user_id>:*``
+      2. ``checkpoint_writes`` rows for the user's thread_id
+      3. ``checkpoints`` rows for the user's thread_id
+      4. ``store`` rows for the user's namespace prefix
+      5. ``store_vectors`` rows (only when the table exists)
+      6. Legacy ``store.adelete`` call for backward-compat rows
+
+    Bug-fix notes (issue #25):
+      - Bug 1: store and store_vectors DELETE used to share one connection
+        context. When EMBED_MODEL=none the store_vectors table does not exist,
+        causing psycopg3 to roll back the entire transaction and silently
+        leaving store rows intact.
+        Fix: each DELETE now runs in its own connection context.
+      - Bug 2: checkpoint_writes was never deleted. Orphaned rows cause
+        INVALID_CHAT_HISTORY on the next session.
+        Fix: checkpoint_writes is deleted in the same transaction as
+        checkpoints.
+      - Bug 3: no cross-section atomicity (accepted-risk approach):
+        each section is independent and idempotent; a failure in one section
+        is logged with enough context for manual reconciliation but does not
+        abort subsequent sections.
     """
-    # TODO: Implement user data clearing functionality
-    # This should:
-    # 1. Clear Redis data for the user
-    # 2. Clear PostgreSQL data (langgraph_checkpoints)
-    # 3. Clear vector memories if store is provided
-    
-    # 1. Clear Redis data - delete keys with pattern matching user_id
-    user_keys = await redis.keys(f"user:{user_id}:*")
-    if user_keys:
-        await redis.delete(*user_keys)
-        logger.info(f"Cleared {len(user_keys)} Redis keys for user {user_id}")    
-        
 
+    embed_model = os.environ.get("EMBED_MODEL", "").strip().lower()
+    vectors_enabled = embed_model != "none" and embed_model != ""
 
-    # 2. Clear PostgreSQL data (langgraph_checkpoints)
+    # ------------------------------------------------------------------ #
+    # Section 1 — Redis                                                    #
+    # ------------------------------------------------------------------ #
+    try:
+        user_keys = await redis.keys(f"user:{user_id}:*")
+        if user_keys:
+            await redis.delete(*user_keys)
+            logger.info("Cleared %d Redis keys for user %s", len(user_keys), user_id)
+        else:
+            logger.debug("No Redis keys found for user %s", user_id)
+    except Exception as exc:
+        logger.error(
+            "Section 1 FAILED — Redis clear for user %s: %s",
+            user_id, exc, exc_info=True,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Section 2 — Checkpoints (checkpoint_writes + checkpoints)           #
+    # Bug 2 fix: checkpoint_writes deleted alongside checkpoints           #
+    # ------------------------------------------------------------------ #
+    try:
+        async with pool.connection() as conn:
+            async with conn.transaction():
+                # checkpoint_writes before checkpoints (FK order)
+                cw = await conn.execute(
+                    "DELETE FROM checkpoint_writes WHERE thread_id = %s",
+                    (user_id,),
+                )
+                ck = await conn.execute(
+                    "DELETE FROM checkpoints WHERE thread_id = %s",
+                    (user_id,),
+                )
+        logger.info(
+            "Cleared checkpoints (%d rows) + checkpoint_writes (%d rows) for user %s",
+            ck.rowcount, cw.rowcount, user_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Section 2 FAILED — checkpoints clear for user %s: %s",
+            user_id, exc, exc_info=True,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Section 3a — store (always)                                          #
+    # Bug 1 fix: own connection context, independent of store_vectors      #
+    # ------------------------------------------------------------------ #
     try:
         async with pool.connection() as conn:
             result = await conn.execute(
-                "DELETE FROM checkpoints WHERE thread_id = %s",
-                (user_id,)
+                "DELETE FROM store WHERE prefix = %s",
+                (str(user_id),),
             )
-            logger.info(f"Cleared PostgreSQL checkpoints for user {user_id}")
-    except Exception as e:
-        logger.error(f"Error clearing PostgreSQL data: {str(e)}")
-    
-      
-    try:
-        # Delete memories with user_id as namespace
+        logger.info(
+            "Deleted %d rows from store for user %s",
+            result.rowcount, user_id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Section 3a FAILED — store DELETE for user %s: %s",
+            user_id, exc, exc_info=True,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Section 3b — store_vectors (only when embedding enabled)             #
+    # Bug 1 fix: separate connection context                               #
+    # ------------------------------------------------------------------ #
+    if vectors_enabled:
         try:
-            # Delete with user_id as namespace (new format)
-            namespace = (str(user_id),)
-            
-            # Use direct SQL queries to delete from both tables
             async with pool.connection() as conn:
-                # Delete from store table
                 result = await conn.execute(
-                    """
-                    DELETE FROM store 
-                    WHERE prefix = %s
-                    """,
-                    (str(user_id),)
+                    "DELETE FROM store_vectors WHERE prefix = %s",
+                    (str(user_id),),
                 )
-                store_deleted = result.rowcount
-                logger.info(f"Deleted {store_deleted} rows from store table for user {user_id}")
-                
-                # Delete from store_vector table
-                result = await conn.execute(
-                    """
-                    DELETE FROM store_vectors
-                    WHERE prefix = %s
-                    """,
-                    (str(user_id),)
-                )
-                vector_deleted = result.rowcount
-                logger.info(f"Deleted {vector_deleted} rows from store_vector table for user {user_id}")
-                
-                logger.info(f"Successfully deleted all memories for user {user_id}")
-            
-        except Exception as e:
-            logger.error(f"Error deleting memories with namespace={user_id}: {str(e)}")
-            
-        # Also try to delete from the old "memories" namespace for backward compatibility
-        try:
-            old_namespace = ("memories",)
-            await store.adelete(old_namespace, user_id)
-            logger.info(f"Deleted memory with namespace=memories, key={user_id}")
-        except Exception as e:
-            logger.debug(f"No memories found in old format (namespace=memories, key={user_id}): {str(e)}")
-            
-    except Exception as e:
-        logger.error(f"Error clearing vector memories: {str(e)}")
-    
-    logger.info(f"Completed data clearing for user {user_id}")
+            logger.info(
+                "Deleted %d rows from store_vectors for user %s",
+                result.rowcount, user_id,
+            )
+        except Exception as exc:
+            logger.error(
+                "Section 3b FAILED — store_vectors DELETE for user %s: %s",
+                user_id, exc, exc_info=True,
+            )
+    else:
+        logger.debug(
+            "EMBED_MODEL=none — skipping store_vectors DELETE for user %s", user_id
+        )
+
+    # ------------------------------------------------------------------ #
+    # Section 3c — legacy store.adelete (backward compat)                  #
+    # ------------------------------------------------------------------ #
+    try:
+        old_namespace = ("memories",)
+        await store.adelete(old_namespace, user_id)
+        logger.info("Deleted legacy memory (namespace=memories, key=%s)", user_id)
+    except Exception as exc:
+        logger.debug(
+            "No legacy memory found (namespace=memories, key=%s): %s", user_id, exc
+        )
+
+    logger.info("Completed data clearing for user %s", user_id)

--- a/tests/test_memory_delete.py
+++ b/tests/test_memory_delete.py
@@ -1,0 +1,263 @@
+"""Regression tests for clear_user_data (issue #25).
+
+Three bugs fixed:
+  Bug 1 — store DELETE silently rolled back when store_vectors table missing
+  Bug 2 — checkpoint_writes never deleted
+  Bug 3 — no cross-section atomicity (accepted-risk: independent sections,
+           each idempotent; saga compensation deferred)
+
+All tests use AsyncMock / MagicMock — no live DB or Redis required.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+USER_ID = "5178700920"
+
+
+def _make_cursor(rowcount: int = 1) -> AsyncMock:
+    cur = AsyncMock()
+    cur.rowcount = rowcount
+    return cur
+
+
+def _make_conn_cm(conn: AsyncMock) -> AsyncMock:
+    """Wrap a conn mock in an async context manager."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _make_checkpoint_conn(
+    cw_rowcount: int = 13,
+    ck_rowcount: int = 6,
+    raises: Exception | None = None,
+) -> AsyncMock:
+    conn = AsyncMock()
+    if raises:
+        conn.execute = AsyncMock(side_effect=raises)
+    else:
+        conn.execute = AsyncMock(side_effect=[
+            _make_cursor(cw_rowcount),   # checkpoint_writes DELETE
+            _make_cursor(ck_rowcount),   # checkpoints DELETE
+        ])
+    txn = AsyncMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn)
+    return conn
+
+
+def _make_store_conn(rowcount: int = 3, raises: Exception | None = None) -> AsyncMock:
+    conn = AsyncMock()
+    if raises:
+        conn.execute = AsyncMock(side_effect=raises)
+    else:
+        conn.execute = AsyncMock(return_value=_make_cursor(rowcount))
+    return conn
+
+
+def _make_vectors_conn(rowcount: int = 2, raises: Exception | None = None) -> AsyncMock:
+    conn = AsyncMock()
+    if raises:
+        conn.execute = AsyncMock(side_effect=raises)
+    else:
+        conn.execute = AsyncMock(return_value=_make_cursor(rowcount))
+    return conn
+
+
+def _make_pool(*conns) -> tuple[MagicMock, list]:
+    """Return (pool, [conn, ...]).  pool.connection() yields conns in order."""
+    pool = MagicMock()
+    cms = [_make_conn_cm(c) for c in conns]
+    pool.connection = MagicMock(side_effect=list(cms))
+    return pool, list(conns)
+
+
+def _make_redis(key_count: int = 2, raises: Exception | None = None) -> AsyncMock:
+    redis = AsyncMock()
+    if raises:
+        redis.keys = AsyncMock(side_effect=raises)
+    else:
+        redis.keys = AsyncMock(return_value=[f"user:{USER_ID}:k{i}" for i in range(key_count)])
+    redis.delete = AsyncMock(return_value=key_count)
+    return redis
+
+
+def _make_store_obj() -> AsyncMock:
+    s = AsyncMock()
+    s.adelete = AsyncMock(return_value=None)
+    return s
+
+
+# --------------------------------------------------------------------------- #
+# Bug 2 regression — checkpoint_writes must be deleted                        #
+# --------------------------------------------------------------------------- #
+
+async def test_checkpoint_writes_deleted(monkeypatch):
+    """Bug 2: checkpoint_writes DELETE must be issued before checkpoints DELETE."""
+    monkeypatch.setenv("EMBED_MODEL", "none")
+
+    ck_conn = _make_checkpoint_conn()
+    store_conn = _make_store_conn()
+    pool, conns = _make_pool(ck_conn, store_conn)
+
+    from db.user_data import clear_user_data
+    await clear_user_data(USER_ID, _make_redis(), pool, _make_store_obj())
+
+    execute_calls = ck_conn.execute.call_args_list
+    assert len(execute_calls) == 2, (
+        f"Expected 2 execute calls on checkpoint conn, got {len(execute_calls)}"
+    )
+
+    first_sql = execute_calls[0].args[0]
+    second_sql = execute_calls[1].args[0]
+
+    assert "checkpoint_writes" in first_sql.lower(), (
+        f"First DELETE must target checkpoint_writes, got: {first_sql!r}"
+    )
+    assert "checkpoints" in second_sql.lower(), (
+        f"Second DELETE must target checkpoints, got: {second_sql!r}"
+    )
+    assert execute_calls[0].args[1] == (USER_ID,)
+    assert execute_calls[1].args[1] == (USER_ID,)
+
+
+# --------------------------------------------------------------------------- #
+# Bug 1 regression — store DELETE not rolled back when store_vectors missing  #
+# --------------------------------------------------------------------------- #
+
+async def test_store_delete_succeeds_when_store_vectors_missing(monkeypatch):
+    """Bug 1: store DELETE must complete even when store_vectors table is absent."""
+    monkeypatch.setenv("EMBED_MODEL", "text-embedding-3-small")
+
+    ck_conn = _make_checkpoint_conn()
+    store_conn = _make_store_conn(rowcount=3)
+    vecs_conn = _make_vectors_conn(
+        raises=Exception('relation "store_vectors" does not exist')
+    )
+    pool, conns = _make_pool(ck_conn, store_conn, vecs_conn)
+
+    from db.user_data import clear_user_data
+    # Must not raise
+    await clear_user_data(USER_ID, _make_redis(), pool, _make_store_obj())
+
+    store_calls = store_conn.execute.call_args_list
+    assert len(store_calls) == 1
+    assert "delete from store" in store_calls[0].args[0].lower()
+    assert store_calls[0].args[1] == (str(USER_ID),)
+
+
+async def test_store_delete_skips_vectors_when_embed_model_none(monkeypatch):
+    """Bug 1: when EMBED_MODEL=none, store_vectors DELETE must not be attempted."""
+    monkeypatch.setenv("EMBED_MODEL", "none")
+
+    ck_conn = _make_checkpoint_conn()
+    store_conn = _make_store_conn()
+    pool, conns = _make_pool(ck_conn, store_conn)  # only 2 CMs — 3rd would explode
+
+    from db.user_data import clear_user_data
+    await clear_user_data(USER_ID, _make_redis(), pool, _make_store_obj())
+
+    # Exactly 2 pool.connection() calls: checkpoint + store
+    assert pool.connection.call_count == 2, (
+        f"Expected 2 pool.connection() calls, got {pool.connection.call_count}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Bug 3 — cross-section independence (accepted-risk verification)             #
+# --------------------------------------------------------------------------- #
+
+async def test_redis_failure_does_not_abort_checkpoints_section(monkeypatch):
+    """Bug 3: Redis failure must not prevent checkpoint delete."""
+    monkeypatch.setenv("EMBED_MODEL", "none")
+
+    ck_conn = _make_checkpoint_conn()
+    store_conn = _make_store_conn()
+    pool, conns = _make_pool(ck_conn, store_conn)
+
+    from db.user_data import clear_user_data
+    await clear_user_data(
+        USER_ID,
+        _make_redis(raises=ConnectionError("Redis down")),
+        pool,
+        _make_store_obj(),
+    )
+
+    assert ck_conn.execute.call_count == 2, (
+        "checkpoints + checkpoint_writes DELETE must run even after Redis failure"
+    )
+
+
+async def test_checkpoints_failure_does_not_abort_store_section(monkeypatch):
+    """Bug 3: checkpoints failure must not prevent store delete."""
+    monkeypatch.setenv("EMBED_MODEL", "none")
+
+    ck_conn = _make_checkpoint_conn(raises=Exception("DB connection error"))
+    store_conn = _make_store_conn(rowcount=3)
+    pool, conns = _make_pool(ck_conn, store_conn)
+
+    from db.user_data import clear_user_data
+    await clear_user_data(USER_ID, _make_redis(), pool, _make_store_obj())
+
+    assert store_conn.execute.call_count == 1, (
+        "store DELETE must run even after checkpoints section failure"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Happy path — full delete EMBED_MODEL=none                                   #
+# --------------------------------------------------------------------------- #
+
+async def test_full_delete_embed_model_none(monkeypatch):
+    """Row 7 happy path with EMBED_MODEL=none."""
+    monkeypatch.setenv("EMBED_MODEL", "none")
+
+    ck_conn = _make_checkpoint_conn(cw_rowcount=13, ck_rowcount=6)
+    store_conn = _make_store_conn(rowcount=3)
+    pool, conns = _make_pool(ck_conn, store_conn)
+    redis = _make_redis(key_count=2)
+    store_obj = _make_store_obj()
+
+    from db.user_data import clear_user_data
+    await clear_user_data(USER_ID, redis, pool, store_obj)
+
+    redis.keys.assert_called_once_with(f"user:{USER_ID}:*")
+    redis.delete.assert_called_once()
+    assert ck_conn.execute.call_count == 2
+    assert store_conn.execute.call_count == 1
+    store_obj.adelete.assert_called_once_with(("memories",), USER_ID)
+
+
+# --------------------------------------------------------------------------- #
+# Happy path — full delete with embedding enabled                             #
+# --------------------------------------------------------------------------- #
+
+async def test_full_delete_with_vectors(monkeypatch):
+    """Row 7 full path: store_vectors also deleted when EMBED_MODEL is set."""
+    monkeypatch.setenv("EMBED_MODEL", "text-embedding-3-small")
+
+    ck_conn = _make_checkpoint_conn(cw_rowcount=13, ck_rowcount=6)
+    store_conn = _make_store_conn(rowcount=3)
+    vecs_conn = _make_vectors_conn(rowcount=3)
+    pool, conns = _make_pool(ck_conn, store_conn, vecs_conn)
+    redis = _make_redis(key_count=2)
+    store_obj = _make_store_obj()
+
+    from db.user_data import clear_user_data
+    await clear_user_data(USER_ID, redis, pool, store_obj)
+
+    assert pool.connection.call_count == 3
+    vecs_calls = vecs_conn.execute.call_args_list
+    assert len(vecs_calls) == 1
+    assert "store_vectors" in vecs_calls[0].args[0].lower()


### PR DESCRIPTION
## Summary

Fixes all three bugs filed in issue #25. Unblocks S1-NS-1.

## Bugs fixed

**Bug 1 — store DELETE silently rolled back when store_vectors missing**
- Root cause: `store` and `store_vectors` DELETE shared one connection context. `EMBED_MODEL=none` causes `store_vectors` table to not exist; psycopg3 rolls back the entire transaction, silently leaving `store` rows intact.
- Fix: each DELETE now runs in its own `async with pool.connection()` context. A `vectors_enabled` flag (based on `EMBED_MODEL` env) controls whether section 3b runs at all.

**Bug 2 — checkpoint_writes never deleted**
- Root cause: only `checkpoints` table was deleted; `checkpoint_writes` was omitted.
- Fix: `checkpoint_writes` deleted in the same transaction as `checkpoints` (FK order: writes before parent).

**Bug 3 — no cross-section atomicity (accepted-risk)**
- Root cause: three independent try/except blocks with no compensation on partial failure.
- Fix: accepted-risk approach — sections remain independent (each is idempotent), each failure emits a structured `ERROR` log with enough context for manual reconciliation. Saga compensation deferred.

## Files changed

| File | Change |
|------|--------|
| `db/user_data.py` | Rewritten with 4-section structure + TYPE_CHECKING import guard |
| `tests/test_memory_delete.py` | New file — 7 regression tests (7/7 passing) |

## Test results

```
tests/test_memory_delete.py .......  7/7 passed
```

## Verification needed before merge

Local Row 7 re-verification checklist is in `docs/STATUS_SUMMARY_2026-06-22.md`.
All three tables (`store`, `checkpoints`, `checkpoint_writes`) must reach 0 after `/reset`.

## Closes

Closes #25 — unblocks S1-NS-MIG → S1-NS-1.