### PR TITLE
fix(boot): S1-BOOT-1 — remove default_user hardcoding

### DIFF
--- a/main.py
+++ b/main.py
@@ -223,19 +223,11 @@ async def main():
             cleanup_interval=300
         )
 
-        logger.info(f"Creating default agent with model {agent_config.llm_model}")
-        default_agent = await agent_factory.create_agent(
-            pg_connection=agent_config.pg_connection,
-            pool=pool,
-            llm_model=agent_config.llm_model,
-            vector_dims=agent_config.vector_dims,
-            embed_model=agent_config.embed_model,
-            user_id="default_user"
-        )
-
         # Create Telegram bot
+        # S1-BOOT-1: default_agent removed — AgentManager creates per-user agents on demand.
+        # TelegramBot no longer accepts a shared default agent.
         logger.info("Starting Telegram bot")
-        telegram_bot = TelegramBot(redis, bot_config, default_agent, pool=pool, store=store)
+        telegram_bot = TelegramBot(redis, bot_config, pool=pool, store=store)
         telegram_bot.message_processor.agent_manager = agent_manager
         telegram_bot.message_processor.config = agent_config
         telegram_bot.message_processor.pool = pool

--- a/telegram_adapter/telegram_bot.py
+++ b/telegram_adapter/telegram_bot.py
@@ -76,12 +76,14 @@ class TelegramTypingIndicator(TypingIndicator):
 class TelegramMessageProcessor(MessageProcessor):
     """Telegram-specific message processor implementation"""
 
-    def __init__(self, redis, agent, config: BotConfig):
+    def __init__(self, redis, config: BotConfig, agent=None):
         super().__init__(
             redis=redis,
             debounce_time=config.debounce_time,
             llm_calls_per_minute=config.llm_calls_per_minute
         )
+        # S1-BOOT-1: agent is None at startup; AgentManager provides per-user agents.
+        # Retained as optional for backward-compat with tests that pass a mock agent.
         self.agent = agent
         # Store updates and contexts for each user
         self.updates: Dict[str, Update] = {}
@@ -187,11 +189,14 @@ class TelegramMessageProcessor(MessageProcessor):
                     config={"configurable": {"user_id": user_id, "thread_id": user_id}},
                 )
             else:
-                # Fall back to the shared agent if agent_manager is not available
-                logger.warning(f"No agent_manager available, using shared agent for user {user_id}")
-                response = await self.agent.ainvoke(
-                    {"messages": [{"role": "user", "content": combined}]},
-                    config={"configurable": {"user_id": user_id, "thread_id": user_id}},
+                # S1-BOOT-1: AgentManager is required. No shared fallback agent exists.
+                # This branch should never be reached in production; raise to surface misconfiguration.
+                logger.error(
+                    "AgentManager not available for user %s — bot misconfigured", user_id
+                )
+                raise RuntimeError(
+                    "AgentManager not configured on TelegramMessageProcessor. "
+                    "Set message_processor.agent_manager after constructing TelegramBot."
                 )
 
             return response["messages"][-1].content
@@ -202,13 +207,14 @@ class TelegramMessageProcessor(MessageProcessor):
 class TelegramBot:
     """Telegram-specific bot implementation"""
 
-    def __init__(self, redis, config: BotConfig, agent, pool=None, store=None):
+    def __init__(self, redis, config: BotConfig, pool=None, store=None):
+        # S1-BOOT-1: agent parameter removed. AgentManager (set after construction)
+        # is the sole source of agents. No default_user shared agent at startup.
         self.redis = redis
         self.config = config
-        self.agent = agent
         self.pool = pool  # Database connection pool
         self.store = store  # Vector store
-        self.message_processor = TelegramMessageProcessor(redis, agent, config)
+        self.message_processor = TelegramMessageProcessor(redis, config)
 
     def create_application(self) -> Application:
         """Configure and return Telegram application"""
@@ -261,7 +267,7 @@ class TelegramBot:
     async def setup(self, application: Application) -> None:
         """Initialize application dependencies"""
         application.bot_data.update({
-            "agent": self.agent,
+            # S1-BOOT-1: no shared agent; AgentManager handles per-user agents.
             "redis": self.redis,
             "pool": self.pool,
             "store": self.store,


### PR DESCRIPTION
## Summary

Removes the `default_user` shared agent created at startup (Sprint 0 baseline correction #2).

## Problem

`main.py` created an `AgentFactory` agent with `user_id="default_user"` on every boot. This agent was passed into `TelegramBot` as a fallback for users who had no per-user agent yet. In production this is a latent cross-tenant memory leak: any message that hits the fallback path reads/writes under the `default_user` namespace, mixing data across real users.

With `AgentManager` in place, every user gets their own agent created on first message. The fallback path is never needed in a correctly configured deployment.

## Changes

| File | Change |
|------|--------|
| `main.py` | Removed `default_agent = await agent_factory.create_agent(..., user_id="default_user")`. `TelegramBot(...)` call updated to remove `agent` positional arg. |
| `telegram_adapter/telegram_bot.py` | `TelegramBot.__init__`: removed `agent` param. `TelegramMessageProcessor.__init__`: `agent` now optional keyword (backward-compat for tests). Fallback path in `process_messages` now raises `RuntimeError` instead of using shared agent — surfaces misconfiguration immediately rather than silently polluting `default_user` namespace. `setup()`: removed `"agent": self.agent` from `bot_data`. |

## Risk

Low. `AgentManager` is wired up immediately after `TelegramBot` construction (`telegram_bot.message_processor.agent_manager = agent_manager`), so the `RuntimeError` branch is unreachable in normal operation. The `RuntimeError` is a safety net for future misconfiguration, not a live risk.

## Related

Sprint 0 baseline correction #2 (issue #23): `default_user` is a live production fallback path, not just a startup shim. Must be removed before multi-tenant work begins (S1-NS-1).

Part of Sprint 1 — can merge independently of S1-NS-MIG.