### PR TITLE
feat(auth): S1-AUTH-1 — add tenant schema (tenants/users/api_keys)

### DIFF
--- a/db/migrations/001_auth_schema.sql
+++ b/db/migrations/001_auth_schema.sql
@@ -1,0 +1,39 @@
+-- Migration: 001_auth_schema
+-- Sprint 1 task: S1-AUTH-1
+-- Description: Create tenant ownership tables (minimal viable schema for S1-NS-MIG)
+-- Idempotent: all statements use CREATE TABLE IF NOT EXISTS / CREATE UNIQUE INDEX IF NOT EXISTS
+-- Do NOT add: created_at, updated_at, is_active, scopes, last_used_at — deferred to Sprint 2+
+
+-- ------------------------------------------------------------------ --
+-- tenants                                                              --
+-- ------------------------------------------------------------------ --
+CREATE TABLE IF NOT EXISTS tenants (
+    id   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL
+);
+
+-- ------------------------------------------------------------------ --
+-- users                                                                --
+-- ------------------------------------------------------------------ --
+CREATE TABLE IF NOT EXISTS users (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id        UUID NOT NULL REFERENCES tenants(id),
+    telegram_user_id TEXT NOT NULL
+);
+
+-- unique: one Telegram user maps to exactly one tenant in this table
+-- (migration mapping key: telegram_user_id → tenant_id)
+CREATE UNIQUE INDEX IF NOT EXISTS users_telegram_user_id_uidx
+    ON users (telegram_user_id);
+
+-- ------------------------------------------------------------------ --
+-- api_keys                                                             --
+-- ------------------------------------------------------------------ --
+CREATE TABLE IF NOT EXISTS api_keys (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id  UUID NOT NULL REFERENCES tenants(id),
+    key_hash   TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_key_hash_uidx
+    ON api_keys (key_hash);

--- a/db/schema.py
+++ b/db/schema.py
@@ -1,0 +1,40 @@
+"""
+Auth schema setup — S1-AUTH-1.
+
+Provides setup_auth_schema(), called once at startup after setup_database().
+All DDL is idempotent (IF NOT EXISTS); safe to run on every boot.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+# Path to the SQL migration file, relative to this module.
+_MIGRATION_FILE = Path(__file__).parent / "migrations" / "001_auth_schema.sql"
+
+
+async def setup_auth_schema(pool) -> None:
+    """Create tenants / users / api_keys tables if they do not exist.
+
+    Reads ``db/migrations/001_auth_schema.sql`` and executes it via the
+    supplied connection pool.  All statements are idempotent — safe to call
+    on every startup.
+
+    Args:
+        pool: AsyncConnectionPool connected to the Pantheon Postgres DB.
+    """
+    sql = _MIGRATION_FILE.read_text()
+
+    async with pool.connection() as conn:
+        async with conn.transaction():
+            await conn.execute(sql)
+
+    logger.info("S1-AUTH-1: auth schema verified / created (tenants, users, api_keys)")

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from config.bot_config import BotConfig
 from config.agent_config import AgentConfig
 from db.postgres_utils import setup_database, create_memory_store
+from db.schema import setup_auth_schema
 from agent.agent_factory import AgentFactory
 from agent.agent_manager import AgentManager
 from telegram_adapter.telegram_bot import TelegramBot
@@ -190,6 +191,9 @@ async def main():
         logger.info("Setting up database connection")
         pool = await setup_database(bot_config.pg_connection)
 
+        # S1-AUTH-1: create tenants / users / api_keys if not exist
+        await setup_auth_schema(pool)
+
         # Create Redis connection
         logger.info(f"Connecting to Redis at {bot_config.redis_url}")
         redis = Redis.from_url(bot_config.redis_url, decode_responses=True)
@@ -223,19 +227,11 @@ async def main():
             cleanup_interval=300
         )
 
-        logger.info(f"Creating default agent with model {agent_config.llm_model}")
-        default_agent = await agent_factory.create_agent(
-            pg_connection=agent_config.pg_connection,
-            pool=pool,
-            llm_model=agent_config.llm_model,
-            vector_dims=agent_config.vector_dims,
-            embed_model=agent_config.embed_model,
-            user_id="default_user"
-        )
-
         # Create Telegram bot
+        # S1-BOOT-1: default_agent removed — AgentManager creates per-user agents on demand.
+        # TelegramBot no longer accepts a shared default agent.
         logger.info("Starting Telegram bot")
-        telegram_bot = TelegramBot(redis, bot_config, default_agent, pool=pool, store=store)
+        telegram_bot = TelegramBot(redis, bot_config, pool=pool, store=store)
         telegram_bot.message_processor.agent_manager = agent_manager
         telegram_bot.message_processor.config = agent_config
         telegram_bot.message_processor.pool = pool

--- a/tests/test_auth_schema.py
+++ b/tests/test_auth_schema.py
@@ -1,0 +1,153 @@
+"""Tests for S1-AUTH-1 auth schema setup.
+
+Verifies that:
+  1. setup_auth_schema() executes the DDL via the pool (smoke test)
+  2. The SQL file contains all required CREATE TABLE statements
+  3. All required unique constraints are present
+  4. No forbidden columns exist in the minimal schema (deferred columns check)
+
+No live DB required — pool is mocked.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+SQL_FILE = Path(__file__).parent.parent / "db" / "migrations" / "001_auth_schema.sql"
+
+
+# --------------------------------------------------------------------------- #
+# SQL file content checks (no DB needed)                                      #
+# --------------------------------------------------------------------------- #
+
+def test_sql_file_exists():
+    assert SQL_FILE.exists(), f"Migration file not found: {SQL_FILE}"
+
+
+def test_tenants_table_defined():
+    sql = SQL_FILE.read_text().lower()
+    assert "create table if not exists tenants" in sql
+
+
+def test_users_table_defined():
+    sql = SQL_FILE.read_text().lower()
+    assert "create table if not exists users" in sql
+
+
+def test_api_keys_table_defined():
+    sql = SQL_FILE.read_text().lower()
+    assert "create table if not exists api_keys" in sql
+
+
+def test_users_tenant_id_not_null():
+    """tenant_id on users must be NOT NULL — every user must belong to a tenant."""
+    sql = SQL_FILE.read_text().lower()
+    # find users table block and confirm not null on tenant_id
+    users_block_start = sql.find("create table if not exists users")
+    users_block_end = sql.find(";", users_block_start)
+    users_block = sql[users_block_start:users_block_end]
+    assert "tenant_id" in users_block
+    assert "not null" in users_block
+
+
+def test_users_tenant_id_foreign_key():
+    sql = SQL_FILE.read_text().lower()
+    assert "references tenants" in sql
+
+
+def test_api_keys_tenant_id_foreign_key():
+    sql = SQL_FILE.read_text().lower()
+    # api_keys table block
+    ak_start = sql.find("create table if not exists api_keys")
+    ak_end = sql.find(";", ak_start)
+    ak_block = sql[ak_start:ak_end]
+    assert "references tenants" in ak_block
+
+
+def test_users_telegram_user_id_unique_index():
+    sql = SQL_FILE.read_text().lower()
+    assert "unique index if not exists users_telegram_user_id_uidx" in sql
+    assert "on users (telegram_user_id)" in sql
+
+
+def test_api_keys_key_hash_unique_index():
+    sql = SQL_FILE.read_text().lower()
+    assert "unique index if not exists api_keys_key_hash_uidx" in sql
+    assert "on api_keys (key_hash)" in sql
+
+
+def test_no_deferred_columns_in_schema():
+    """Deferred columns must NOT be in the minimal schema."""
+    raw = SQL_FILE.read_text()
+    lines = [l for l in raw.splitlines() if not l.strip().startswith("--")]
+    sql = " ".join(lines).lower()
+    forbidden = ["created_at", "updated_at", "is_active", "scopes", "last_used_at"]
+    present = [col for col in forbidden if col in sql]
+    assert not present, "Deferred columns in schema: " + str(present)
+
+
+def test_schema_is_idempotent():
+    """Every CREATE TABLE and CREATE INDEX must use IF NOT EXISTS."""
+    sql = SQL_FILE.read_text()
+    create_stmts = re.findall(r"CREATE\s+(UNIQUE\s+)?(?:TABLE|INDEX)\s+(\w+)", sql, re.IGNORECASE)
+    non_idempotent = []
+    for match in re.finditer(r"CREATE\s+(?:UNIQUE\s+)?(?:TABLE|INDEX)(?!\s+IF\s+NOT\s+EXISTS)", sql, re.IGNORECASE):
+        non_idempotent.append(match.group(0))
+    assert not non_idempotent, (
+        f"Non-idempotent CREATE statements (missing IF NOT EXISTS): {non_idempotent}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# setup_auth_schema() execution smoke test (mocked pool)                      #
+# --------------------------------------------------------------------------- #
+
+async def test_setup_auth_schema_executes_sql():
+    """setup_auth_schema() must call conn.execute() with the DDL content."""
+    conn = AsyncMock()
+    txn = AsyncMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn)
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=cm)
+
+    from db.schema import setup_auth_schema
+    await setup_auth_schema(pool)
+
+    pool.connection.assert_called_once()
+    conn.execute.assert_called_once()
+    sql_arg = conn.execute.call_args.args[0]
+    assert "CREATE TABLE IF NOT EXISTS tenants" in sql_arg
+    assert "CREATE TABLE IF NOT EXISTS users" in sql_arg
+    assert "CREATE TABLE IF NOT EXISTS api_keys" in sql_arg
+
+
+async def test_setup_auth_schema_uses_transaction():
+    """setup_auth_schema() must wrap DDL in a transaction."""
+    conn = AsyncMock()
+    txn = AsyncMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=txn)
+
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=cm)
+
+    from db.schema import setup_auth_schema
+    await setup_auth_schema(pool)
+
+    conn.transaction.assert_called_once()


### PR DESCRIPTION
## Summary

Implements S1-AUTH-1 — minimal tenant ownership schema required before S1-NS-MIG and S1-NS-1 can proceed.

## Schema (minimal, per design decision)

```sql
tenants  (id UUID PK, name TEXT NOT NULL)
users    (id UUID PK, tenant_id UUID NOT NULL FK→tenants, telegram_user_id TEXT UNIQUE)
api_keys (id UUID PK, tenant_id UUID NOT NULL FK→tenants, key_hash TEXT UNIQUE)
```

Deliberately excluded (Sprint 2+): created_at, updated_at, is_active, scopes, last_used_at.

## Files

| File | Purpose |
|------|---------|
| `db/migrations/001_auth_schema.sql` | Idempotent DDL (IF NOT EXISTS throughout) |
| `db/schema.py` | `setup_auth_schema(pool)` — reads SQL file, runs in transaction |
| `main.py` | Calls `setup_auth_schema(pool)` after `setup_database()` |
| `tests/test_auth_schema.py` | 13 tests: SQL structure + unique indexes + no deferred columns + mock execution |

## Test results

```
tests/test_auth_schema.py .............  13/13 passed
```

## What this unblocks

- S1-NS-MIG: `tenant_id` now exists as a real FK target for namespace migration mapping
- S1-AUTH-2/3: middleware and Redis tenant namespace can be built on top

## Note on `main.py`

This PR includes the S1-BOOT-1 main.py changes from PR #27 as base (branched from main after #26 merge). If #27 merges first, the main.py diff here will reduce to just the two auth lines.