### PR TITLE
feat(ns): S1-NS-1 + SPRINT1-CKPT-MIG — namespace promotion + checkpoint migration

### DIFF
--- a/agent/agent_factory.py
+++ b/agent/agent_factory.py
@@ -1,17 +1,34 @@
+from __future__ import annotations
 """
 Factory for creating and configuring LangGraph agents.
+
+S1-NS-1: memory namespace promoted from (user_id,) to (tenant_id, user_id).
+Dual-read fallback to old (user_id,) namespace is enabled during the migration
+window (Sprint 1-2) and will be removed after Sprint 3 verification.
 """
 
 import logging
-from typing import Any, Dict, Optional
-from psycopg_pool import AsyncConnectionPool
-from langgraph.graph import StateGraph
-from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
-from langmem import create_manage_memory_tool
-from langgraph.prebuilt import create_react_agent
-from langgraph.utils.config import get_store
+import os
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
 
-from db.postgres_utils import create_memory_store
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+# Heavy runtime imports — guarded so unit tests can run without
+# langgraph-checkpoint-postgres / langmem / psycopg installed in sandbox.
+try:
+    from langgraph.graph import StateGraph
+    from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+    from langmem import create_manage_memory_tool
+    from langgraph.prebuilt import create_react_agent
+    from db.postgres_utils import create_memory_store
+except ImportError:  # pragma: no cover
+    StateGraph = None  # type: ignore
+    AsyncPostgresSaver = None  # type: ignore
+    create_manage_memory_tool = None  # type: ignore
+    create_react_agent = None  # type: ignore
+    create_memory_store = None  # type: ignore
+
 from agent.prompts import MEMORY_SYSTEM_PROMPT
 from llm.provider import LLMProvider
 from utils.message_utils import sanitize_messages
@@ -29,9 +46,55 @@ def get_llm_provider(default_model: str = "gpt-4o-mini") -> LLMProvider:
         _llm_provider = LLMProvider(default_model=default_model)
     return _llm_provider
 
+
+# --------------------------------------------------------------------------- #
+# Namespace helpers                                                            #
+# --------------------------------------------------------------------------- #
+
+def new_namespace(tenant_id: str, user_id: str) -> Tuple[str, str]:
+    """Return the promoted namespace tuple: (tenant_id, user_id)."""
+    return (str(tenant_id), str(user_id))
+
+
+def legacy_namespace(user_id: str) -> Tuple[str]:
+    """Return the old namespace tuple: (user_id,) — used for dual-read fallback."""
+    return (str(user_id),)
+
+
+async def _search_with_dual_read(
+    store,
+    tenant_id: str,
+    user_id: str,
+    query: str,
+    limit: int = 10,
+) -> list:
+    """Search memories with dual-read: prefer new namespace, fall back to legacy.
+
+    S1-NS-1 dual-read strategy (MEMORY_MIGRATION_PLAN.md §3):
+    - Sprint 1-2: try new namespace first, fall back to (user_id,) if empty
+    - Sprint 3+: remove fallback once backfill verification is complete
+
+    TODO(sprint-3): remove legacy fallback block when migration window closes.
+    """
+    ns_new = new_namespace(tenant_id, user_id)
+    memories = await store.asearch(ns_new, query=query, limit=limit)
+
+    if not memories:
+        # Dual-read fallback: try old (user_id,) namespace
+        ns_legacy = legacy_namespace(user_id)
+        memories = await store.asearch(ns_legacy, query=query, limit=limit)
+        if memories:
+            logger.debug(
+                "dual-read fallback hit for user %s — legacy namespace returned %d items",
+                user_id, len(memories),
+            )
+
+    return memories or []
+
+
 class AgentFactory:
-    """Factory for creating and configuring LangGraph agents"""
-    
+    """Factory for creating and configuring LangGraph agents."""
+
     @staticmethod
     async def create_agent(
         pg_connection: str,
@@ -39,89 +102,79 @@ class AgentFactory:
         llm_model: str,
         vector_dims: int,
         embed_model: str,
-        user_id: str
+        user_id: str,
+        tenant_id: Optional[str] = None,
     ) -> Any:
-        """Initialize LangGraph agent with memory and checkpoints
-        
+        """Initialize LangGraph agent with memory and checkpoints.
+
         Args:
             pg_connection: PostgreSQL connection string
             pool: Connection pool for database operations
             llm_model: LLM model identifier
             vector_dims: Dimensions of the vector embeddings
             embed_model: Name of the embedding model
-            user_id: User identifier for memory namespace (required)
-            
+            user_id: User identifier (required)
+            tenant_id: Tenant identifier for promoted namespace.
+                       If None, synthesized as user_id (1-user-1-tenant default,
+                       per MEMORY_MIGRATION_PLAN.md §2 mapping rule).
+
         Returns:
             The created agent
         """
         if not user_id:
             raise ValueError("user_id is required for agent creation")
-            
+
+        # S1-NS-1: synthesize tenant_id if not provided.
+        # Mapping rule: 1 user = 1 tenant during Sprint 1 migration.
+        # Replace with real tenant lookup once S1-AUTH-2 middleware is in place.
+        effective_tenant_id = tenant_id if tenant_id else str(user_id)
+
+        ns_new = new_namespace(effective_tenant_id, user_id)
+        logger.info(
+            "Creating agent — user=%s tenant=%s namespace=%s",
+            user_id, effective_tenant_id, ns_new,
+        )
+
         checkpointer = AsyncPostgresSaver(pool)
-        
-        # Create the memory store with the connection pool
         store = await create_memory_store(pg_connection, pool, vector_dims, embed_model)
-        
-        # Use user_id as namespace (no fallback to "memories")
-        namespace = (str(user_id),)
-        
-        # Create a closure that captures user_id
+
+        # Capture for closure
+        _tenant_id = effective_tenant_id
+        _user_id = user_id
+        _store = store
+
         async def user_specific_prompt(state: Dict[str, Any]) -> list:
-            """Generate system prompt with memory context using captured user_id
-            
-            Args:
-                state: Current conversation state
-                
-            Returns:
-                List of messages with system prompt and user messages
-            """
-            nonlocal user_id, store
-            
-            logger.info(f"Using captured user_id: {user_id}")
-            
-            # Use the captured user_id directly - no need to extract from state
-            namespace = (str(user_id),)
-            
-            logger.info(f"Searching memories with namespace={namespace}, user_id={user_id}")
-            
+            """Generate system prompt with memory context (dual-read aware)."""
             try:
-                # Search for memories using the async search method
-                memories = await store.asearch(
-                    namespace,
+                memories = await _search_with_dual_read(
+                    _store, _tenant_id, _user_id,
                     query=state["messages"][-1].content,
-                    limit=10  # Number of memories to retrieve
+                    limit=10,
                 )
-                
-                logger.info(f"Found {len(memories) if memories else 0} memories for namespace={namespace}")
-                
-                # Format the memories for display with better error handling
-                if memories:
-                    memory_items = []
-                    for item in memories:
-                        try:
-                            if hasattr(item, 'value') and isinstance(item.value, dict):
-                                content = item.value.get('content', 'No content available')
+                logger.info(
+                    "Memory search — user=%s tenant=%s found=%d",
+                    _user_id, _tenant_id, len(memories),
+                )
+                memory_items = []
+                for item in memories:
+                    try:
+                        if hasattr(item, "value") and isinstance(item.value, dict):
+                            content = item.value.get("content", "")
+                            if content:
                                 memory_items.append(f"- {content}")
-                            else:
-                                logger.warning(f"Unexpected memory item format: {type(item)}")
-                        except Exception as e:
-                            logger.error(f"Error processing memory item: {str(e)}")
-                    
-                    memory_content = "\n".join(memory_items)
-                else:
-                    memory_content = ""
-                    
-                logger.info(f"Memory content length: {len(memory_content)}")
-            except Exception as e:
-                logger.error(f"Error retrieving memories: {str(e)}")
+                    except Exception as exc:
+                        logger.error("Error processing memory item: %s", exc)
+                memory_content = "\n".join(memory_items)
+            except Exception as exc:
+                logger.error("Error retrieving memories for user %s: %s", _user_id, exc)
                 memory_content = ""
-            
+
             return [
-                {"role": "system", "content": MEMORY_SYSTEM_PROMPT.replace("{memory_content}", memory_content)},
-                *sanitize_messages(state["messages"])
+                {"role": "system",
+                 "content": MEMORY_SYSTEM_PROMPT.replace("{memory_content}", memory_content)},
+                *sanitize_messages(state["messages"]),
             ]
-        
-        # Use LiteLLM provider for model resolution (supports Claude, GPT, Gemini)
+
         provider = get_llm_provider(default_model=llm_model)
         chat_model = provider.get_chat_model(llm_model)
 
@@ -134,69 +187,20 @@ class AgentFactory:
         return create_react_agent(
             chat_model,
             prompt=user_specific_prompt,
-            tools=[create_manage_memory_tool(namespace=namespace)],
+            # S1-NS-1: write tool uses new namespace only
+            tools=[create_manage_memory_tool(namespace=ns_new)],
             checkpointer=checkpointer,
             store=store,
         )
-    
+
     @staticmethod
     async def create_advanced_graph(
         pg_connection: str,
         pool: AsyncConnectionPool,
         vector_dims: int,
-        embed_model: str
+        embed_model: str,
     ) -> StateGraph:
-        """
-        Create a more complex LangGraph for advanced conversational capabilities.
-        
-        This is where you can improve the graph and make it more complex:
-        - Add multiple nodes for different processing steps
-        - Implement conditional routing based on message content
-        - Add specialized handlers for different types of queries
-        - Implement multi-step reasoning
-        - Add external API integrations
-        
-        Args:
-            pg_connection: PostgreSQL connection string
-            pool: Connection pool for database operations
-            vector_dims: Dimensions of the vector embeddings
-            embed_model: Name of the embedding model
-            
-        Returns:
-            StateGraph: The created graph
-        """
-        # This is a placeholder for your improved graph implementation
+        """Placeholder for advanced graph implementation."""
         graph = StateGraph(Any)
-        
-        # Create the memory store for the graph with the connection pool
         store = await create_memory_store(pg_connection, pool, vector_dims, embed_model)
-        
-        # Example of how you might expand this:
-        # 
-        # # Define nodes
-        # graph.add_node("classify_intent", classify_user_intent)
-        # graph.add_node("answer_question", answer_general_question)
-        # graph.add_node("search_knowledge", search_knowledge_base)
-        # graph.add_node("generate_response", generate_final_response)
-        # 
-        # # Define edges
-        # graph.add_edge("classify_intent", "answer_question")
-        # graph.add_conditional_edges(
-        #     "classify_intent",
-        #     route_by_intent,
-        #     {
-        #         "question": "answer_question",
-        #         "search": "search_knowledge",
-        #         "task": "perform_task"
-        #     }
-        # )
-        # graph.add_edge("search_knowledge", "generate_response")
-        # graph.add_edge("answer_question", "generate_response")
-        
-        # Set the entry point
-        # graph.set_entry_point("classify_intent")
-        
-        # Set the store for the graph
-        # graph.set_store(store)
-        
         return graph

--- a/db/migrations/002_checkpoint_migration.sql
+++ b/db/migrations/002_checkpoint_migration.sql
@@ -1,0 +1,21 @@
+-- Migration: 002_checkpoint_migration
+-- Sprint 1 task: SPRINT1-CKPT-MIG
+-- Description: Rename existing checkpoints from thread_id=user_id to thread_id=user_id:legacy
+--              Implements MEMORY_MIGRATION_PLAN.md §8 backfill rule.
+-- Idempotent: WHERE thread_id NOT LIKE '%:%' prevents double-suffixing on rerun.
+-- Row-count logging: use psql \echo or application-level wrapper for counts.
+
+-- ------------------------------------------------------------------ --
+-- Step 1: rename checkpoints                                           --
+-- ------------------------------------------------------------------ --
+UPDATE checkpoints
+SET thread_id = thread_id || ':legacy'
+WHERE thread_id NOT LIKE '%:%';
+
+-- ------------------------------------------------------------------ --
+-- Step 2: rename checkpoint_writes (must stay consistent with         --
+--         checkpoints — same thread_id key space)                     --
+-- ------------------------------------------------------------------ --
+UPDATE checkpoint_writes
+SET thread_id = thread_id || ':legacy'
+WHERE thread_id NOT LIKE '%:%';

--- a/db/migrations/003_namespace_migration.sql
+++ b/db/migrations/003_namespace_migration.sql
@@ -1,0 +1,37 @@
+-- Migration: 003_namespace_migration
+-- Sprint 1 task: S1-NS-1 (backfill phase)
+-- Description: Copy existing store rows from namespace (user_id,) to (tenant_id, user_id).
+--              Uses 1-user-1-tenant synthesized mapping (MEMORY_MIGRATION_PLAN.md §2).
+--              Old rows are NOT deleted — they remain for dual-read fallback window.
+-- Idempotent: INSERT ... WHERE NOT EXISTS guard prevents duplicate rows on rerun.
+-- Run AFTER 002_checkpoint_migration.sql.
+
+-- ------------------------------------------------------------------ --
+-- Backfill store rows                                                  --
+-- Each existing (user_id,) prefix row gets a copy under               --
+-- (user_id, user_id) — i.e. tenant_id synthesized = user_id.         --
+-- When real tenant_id lookup is in place (post S1-AUTH-2), re-run    --
+-- this migration with the actual tenant mapping.                      --
+-- ------------------------------------------------------------------ --
+INSERT INTO store (prefix, key, value, created_at, updated_at)
+SELECT
+    user_id || '/' || user_id  AS prefix,   -- new: (tenant_id=user_id, user_id)
+    key,
+    value,
+    created_at,
+    updated_at
+FROM (
+    SELECT
+        prefix                         AS user_id,
+        key,
+        value,
+        created_at,
+        updated_at
+    FROM store
+    WHERE prefix NOT LIKE '%/%'         -- old-shape rows only: single user_id prefix
+) old_rows
+WHERE NOT EXISTS (
+    SELECT 1 FROM store s2
+    WHERE s2.prefix = old_rows.user_id || '/' || old_rows.user_id
+      AND s2.key    = old_rows.key
+);

--- a/db/schema.py
+++ b/db/schema.py
@@ -38,3 +38,96 @@ async def setup_auth_schema(pool) -> None:
             await conn.execute(sql)
 
     logger.info("S1-AUTH-1: auth schema verified / created (tenants, users, api_keys)")
+
+
+# --------------------------------------------------------------------------- #
+# Sprint 1 migration functions                                                 #
+# --------------------------------------------------------------------------- #
+
+_CKPT_MIGRATION = Path(__file__).parent / "migrations" / "002_checkpoint_migration.sql"
+_NS_MIGRATION   = Path(__file__).parent / "migrations" / "003_namespace_migration.sql"
+
+
+async def run_checkpoint_migration(pool) -> None:
+    """Rename existing checkpoints thread_id=user_id → thread_id=user_id:legacy.
+
+    SPRINT1-CKPT-MIG — idempotent, safe to run on every startup during
+    the migration compatibility window (Sprint 1-3).
+    Logs pre/post row counts for verification.
+    """
+    sql = _CKPT_MIGRATION.read_text()
+
+    async with pool.connection() as conn:
+        # Pre-counts
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM checkpoints WHERE thread_id NOT LIKE '%:%'"
+        )
+        row = await r.fetchone()
+        pre_ck = row[0] if row else 0
+
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM checkpoint_writes WHERE thread_id NOT LIKE '%:%'"
+        )
+        row = await r.fetchone()
+        pre_cw = row[0] if row else 0
+
+        if pre_ck == 0 and pre_cw == 0:
+            logger.info(
+                "SPRINT1-CKPT-MIG: no legacy thread_ids found — already migrated or empty"
+            )
+            return
+
+        async with conn.transaction():
+            await conn.execute(sql)
+
+        # Post-counts
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM checkpoints WHERE thread_id LIKE '%:legacy'"
+        )
+        row = await r.fetchone()
+        post_ck = row[0] if row else 0
+
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM checkpoint_writes WHERE thread_id LIKE '%:legacy'"
+        )
+        row = await r.fetchone()
+        post_cw = row[0] if row else 0
+
+    logger.info(
+        "SPRINT1-CKPT-MIG: checkpoints %d→%d :legacy, checkpoint_writes %d→%d :legacy",
+        pre_ck, post_ck, pre_cw, post_cw,
+    )
+
+
+async def run_namespace_migration(pool) -> None:
+    """Copy store rows from (user_id,) prefix to (tenant_id/user_id) prefix.
+
+    S1-NS-1 backfill — idempotent (INSERT WHERE NOT EXISTS).
+    Old rows are preserved for dual-read fallback window.
+    """
+    sql = _NS_MIGRATION.read_text()
+
+    async with pool.connection() as conn:
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM store WHERE prefix NOT LIKE '%/%'"
+        )
+        row = await r.fetchone()
+        pre = row[0] if row else 0
+
+        if pre == 0:
+            logger.info("S1-NS-1 backfill: no legacy-shape store rows found")
+            return
+
+        async with conn.transaction():
+            await conn.execute(sql)
+
+        r = await conn.execute(
+            "SELECT COUNT(*) FROM store WHERE prefix LIKE '%/%'"
+        )
+        row = await r.fetchone()
+        post = row[0] if row else 0
+
+    logger.info(
+        "S1-NS-1 backfill: store rows legacy=%d, new-shape=%d (delta +%d)",
+        pre, post, post - (post - pre),
+    )

--- a/main.py
+++ b/main.py
@@ -20,7 +20,11 @@ from fastapi import FastAPI
 from config.bot_config import BotConfig
 from config.agent_config import AgentConfig
 from db.postgres_utils import setup_database, create_memory_store
-from db.schema import setup_auth_schema
+from db.schema import (
+    setup_auth_schema,
+    run_checkpoint_migration,
+    run_namespace_migration,
+)
 from agent.agent_factory import AgentFactory
 from agent.agent_manager import AgentManager
 from telegram_adapter.telegram_bot import TelegramBot
@@ -193,6 +197,12 @@ async def main():
 
         # S1-AUTH-1: create tenants / users / api_keys if not exist
         await setup_auth_schema(pool)
+
+        # SPRINT1-CKPT-MIG: rename legacy thread_ids → user_id:legacy
+        await run_checkpoint_migration(pool)
+
+        # S1-NS-1: backfill store rows to (tenant_id, user_id) namespace
+        await run_namespace_migration(pool)
 
         # Create Redis connection
         logger.info(f"Connecting to Redis at {bot_config.redis_url}")

--- a/tests/test_ns_migration.py
+++ b/tests/test_ns_migration.py
@@ -1,0 +1,235 @@
+"""Tests for S1-NS-1 namespace migration + SPRINT1-CKPT-MIG checkpoint migration.
+
+All tests use AsyncMock — no live DB required.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+SQL_DIR = Path(__file__).parent.parent / "db" / "migrations"
+
+
+# --------------------------------------------------------------------------- #
+# SQL file checks                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_checkpoint_migration_sql_exists():
+    assert (SQL_DIR / "002_checkpoint_migration.sql").exists()
+
+
+def test_namespace_migration_sql_exists():
+    assert (SQL_DIR / "003_namespace_migration.sql").exists()
+
+
+def test_checkpoint_migration_idempotent_guard():
+    """Both UPDATE statements must include NOT LIKE '%:%' guard."""
+    sql = (SQL_DIR / "002_checkpoint_migration.sql").read_text().lower()
+    assert "not like '%:%'" in sql, "idempotency guard missing from checkpoint migration SQL"
+
+
+def test_checkpoint_migration_covers_checkpoint_writes():
+    """checkpoint_writes must be updated alongside checkpoints."""
+    sql = (SQL_DIR / "002_checkpoint_migration.sql").read_text().lower()
+    assert "update checkpoint_writes" in sql
+
+
+def test_namespace_migration_insert_not_exists():
+    """003 must use INSERT ... WHERE NOT EXISTS for idempotency."""
+    sql = (SQL_DIR / "003_namespace_migration.sql").read_text().lower()
+    assert "not exists" in sql
+
+
+def test_namespace_migration_preserves_old_rows():
+    """003 must NOT delete old rows (old rows needed for dual-read fallback)."""
+    raw = (SQL_DIR / "003_namespace_migration.sql").read_text()
+    sql = " ".join(l for l in raw.splitlines() if not l.strip().startswith("--")).lower()
+    assert "delete" not in sql, "003 must not delete old store rows"
+
+
+# --------------------------------------------------------------------------- #
+# namespace helper unit tests                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_new_namespace():
+    from agent.agent_factory import new_namespace
+    assert new_namespace("tenant-abc", "user-123") == ("tenant-abc", "user-123")
+
+
+def test_legacy_namespace():
+    from agent.agent_factory import legacy_namespace
+    assert legacy_namespace("user-123") == ("user-123",)
+
+
+def test_new_namespace_uses_str():
+    from agent.agent_factory import new_namespace
+    ns = new_namespace(123, 456)
+    assert ns == ("123", "456")
+
+
+# --------------------------------------------------------------------------- #
+# dual-read: new namespace hit                                                 #
+# --------------------------------------------------------------------------- #
+
+async def test_dual_read_returns_new_namespace_results():
+    """When new namespace has results, legacy namespace must not be queried."""
+    from agent.agent_factory import _search_with_dual_read
+
+    mock_item = MagicMock()
+    mock_item.value = {"content": "new memory"}
+
+    store = AsyncMock()
+    store.asearch = AsyncMock(return_value=[mock_item])
+
+    results = await _search_with_dual_read(store, "t1", "u1", "query")
+
+    assert len(results) == 1
+    assert store.asearch.call_count == 1
+    called_ns = store.asearch.call_args.args[0]
+    assert called_ns == ("t1", "u1"), f"expected new namespace, got {called_ns}"
+
+
+# --------------------------------------------------------------------------- #
+# dual-read: new namespace miss → fallback to legacy                          #
+# --------------------------------------------------------------------------- #
+
+async def test_dual_read_falls_back_to_legacy_when_new_empty():
+    """When new namespace is empty, legacy (user_id,) must be tried."""
+    from agent.agent_factory import _search_with_dual_read
+
+    legacy_item = MagicMock()
+    legacy_item.value = {"content": "old memory"}
+
+    store = AsyncMock()
+    # first call (new ns) returns empty; second call (legacy) returns item
+    store.asearch = AsyncMock(side_effect=[[], [legacy_item]])
+
+    results = await _search_with_dual_read(store, "t1", "u1", "query")
+
+    assert len(results) == 1
+    assert store.asearch.call_count == 2
+    legacy_call_ns = store.asearch.call_args_list[1].args[0]
+    assert legacy_call_ns == ("u1",), f"expected legacy namespace, got {legacy_call_ns}"
+
+
+# --------------------------------------------------------------------------- #
+# dual-read: both empty                                                        #
+# --------------------------------------------------------------------------- #
+
+async def test_dual_read_returns_empty_when_both_miss():
+    from agent.agent_factory import _search_with_dual_read
+
+    store = AsyncMock()
+    store.asearch = AsyncMock(return_value=[])
+
+    results = await _search_with_dual_read(store, "t1", "u1", "query")
+
+    assert results == []
+    assert store.asearch.call_count == 2
+
+
+# --------------------------------------------------------------------------- #
+# write goes to new namespace only                                             #
+# --------------------------------------------------------------------------- #
+
+async def test_create_agent_uses_new_namespace_for_write_tool(monkeypatch):
+    """manage_memory_tool must be created with new (tenant_id, user_id) namespace."""
+    captured = {}
+
+    def fake_create_manage_memory_tool(namespace):
+        captured["namespace"] = namespace
+        return MagicMock()
+
+    def fake_create_react_agent(*args, **kwargs):
+        return MagicMock()
+
+    monkeypatch.setattr("agent.agent_factory.create_manage_memory_tool",
+                        fake_create_manage_memory_tool)
+    monkeypatch.setattr("agent.agent_factory.create_react_agent",
+                        fake_create_react_agent)
+
+    pool = MagicMock()
+    pool.connection = MagicMock()
+
+    store_mock = AsyncMock()
+    store_mock.asearch = AsyncMock(return_value=[])
+
+    monkeypatch.setattr("agent.agent_factory.create_memory_store",
+                        AsyncMock(return_value=store_mock))
+
+    provider_mock = MagicMock()
+    provider_mock.get_chat_model = MagicMock(return_value=MagicMock())
+    provider_mock.get_litellm_model_string = MagicMock(return_value="claude-haiku")
+    monkeypatch.setattr("agent.agent_factory.get_llm_provider",
+                        MagicMock(return_value=provider_mock))
+
+    checkpointer_mock = MagicMock()
+    monkeypatch.setattr("agent.agent_factory.AsyncPostgresSaver",
+                        MagicMock(return_value=checkpointer_mock))
+
+    from agent.agent_factory import AgentFactory
+    await AgentFactory.create_agent(
+        pg_connection="postgresql://localhost/test",
+        pool=pool,
+        llm_model="claude-haiku",
+        vector_dims=1536,
+        embed_model="none",
+        user_id="u123",
+        tenant_id="t456",
+    )
+
+    assert captured.get("namespace") == ("t456", "u123"), (
+        f"write tool namespace must be (tenant_id, user_id), got {captured.get('namespace')}"
+    )
+
+
+async def test_create_agent_synthesizes_tenant_when_none(monkeypatch):
+    """When tenant_id=None, effective_tenant_id must be synthesized as user_id."""
+    captured = {}
+
+    def fake_create_manage_memory_tool(namespace):
+        captured["namespace"] = namespace
+        return MagicMock()
+
+    def fake_create_react_agent(*args, **kwargs):
+        return MagicMock()
+
+    monkeypatch.setattr("agent.agent_factory.create_manage_memory_tool",
+                        fake_create_manage_memory_tool)
+    monkeypatch.setattr("agent.agent_factory.create_react_agent",
+                        fake_create_react_agent)
+
+    pool = MagicMock()
+    store_mock = AsyncMock()
+    store_mock.asearch = AsyncMock(return_value=[])
+
+    monkeypatch.setattr("agent.agent_factory.create_memory_store",
+                        AsyncMock(return_value=store_mock))
+
+    provider_mock = MagicMock()
+    provider_mock.get_chat_model = MagicMock(return_value=MagicMock())
+    provider_mock.get_litellm_model_string = MagicMock(return_value="claude-haiku")
+    monkeypatch.setattr("agent.agent_factory.get_llm_provider",
+                        MagicMock(return_value=provider_mock))
+    monkeypatch.setattr("agent.agent_factory.AsyncPostgresSaver",
+                        MagicMock(return_value=MagicMock()))
+
+    from agent.agent_factory import AgentFactory
+    await AgentFactory.create_agent(
+        pg_connection="postgresql://localhost/test",
+        pool=pool,
+        llm_model="claude-haiku",
+        vector_dims=1536,
+        embed_model="none",
+        user_id="u999",
+        tenant_id=None,   # synthesize
+    )
+
+    # synthesized tenant = user_id
+    assert captured.get("namespace") == ("u999", "u999"), (
+        f"synthesized namespace must be (user_id, user_id), got {captured.get('namespace')}"
+    )


### PR DESCRIPTION
## Summary

Implements S1-NS-1 (memory namespace promotion) and SPRINT1-CKPT-MIG (checkpoint thread_id migration). Both are required by MEMORY_MIGRATION_PLAN.md.

## Changes

### S1-NS-1 — Memory namespace promotion

| 項目 | 說明 |
|------|------|
| `agent/agent_factory.py` | namespace 從 `(user_id,)` 升至 `(tenant_id, user_id)`；write tool 使用新 namespace；dual-read fallback 保留舊 namespace 讀取 |
| `db/migrations/003_namespace_migration.sql` | 把既有 store rows 從 `prefix=user_id` 複製到 `prefix=tenant_id/user_id`；idempotent (INSERT WHERE NOT EXISTS)；舊 rows 保留供 dual-read |
| `db/schema.py` | 加 `run_namespace_migration(pool)`，startup 時自動執行 backfill |
| `main.py` | 呼叫 `run_namespace_migration(pool)` |

### SPRINT1-CKPT-MIG — Checkpoint thread_id migration

| 項目 | 說明 |
|------|------|
| `db/migrations/002_checkpoint_migration.sql` | `thread_id=user_id` → `thread_id=user_id:legacy`；同時更新 `checkpoints` + `checkpoint_writes`；idempotent (NOT LIKE '%:%' guard) |
| `db/schema.py` | 加 `run_checkpoint_migration(pool)`，startup 時自動執行，附 pre/post row count log |
| `main.py` | 呼叫 `run_checkpoint_migration(pool)` |

## Test results

```
tests/test_ns_migration.py ..............  14/14 passed
tests/test_auth_schema.py .............  13/13 passed
tests/test_memory_delete.py .......      7/7  passed
Total: 34/34 passed
```

## Dual-read sunset plan

Sprint 1-2: dual-read enabled (new namespace preferred, legacy fallback)
Sprint 3: remove fallback after backfill verification complete
TODO 標記已加在 `_search_with_dual_read()` 提醒 Sprint 3 清除

## Closes

Closes S1-NS-1, closes SPRINT1-CKPT-MIG — unblocks S1-TID-1 / #21