### PR TITLE
feat(session): #21 — collapse session layer into core/session.py

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -1,0 +1,66 @@
+"""
+Session lifecycle management.
+
+This module is the **sole producer** of ``thread_id``.
+Adapters (Telegram, Web UI, future REST/SSE clients) MUST NOT construct
+``thread_id`` themselves — they call :func:`get_or_create_session` and use
+the returned value.
+
+Current mode: T1 — ``thread_id == user_id`` (single conversation per user).
+S1-TID-1 will switch to T2 by changing :func:`make_thread_id` only.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+
+def make_thread_id(user_id: str, session_id: str) -> str:
+    """Return the canonical ``thread_id`` for a user + session pair.
+
+    T1 (current): returns ``user_id`` — one persistent thread per user.
+    T2 (S1-TID-1): returns ``f"{user_id}:{session_id}"`` — per-session threads.
+
+    This is the single line that changes when Step 1.5 switches from T1 to T2.
+    """
+    return user_id  # T1 — change to f"{user_id}:{session_id}" in S1-TID-1
+
+
+class SessionManager:
+    """Manages Pantheon session lifecycle.
+
+    The sole authority for ``thread_id`` production.  Adapters pass only
+    ``user_id`` (and optionally adapter-specific metadata); they receive back
+    a ``(session_id, thread_id)`` pair and must not derive either themselves.
+    """
+
+    def __init__(self, redis: "Redis") -> None:
+        self._redis = redis
+
+    async def get_or_create_session(self, user_id: str) -> tuple[str, str]:
+        """Return ``(session_id, thread_id)`` for the user's current session.
+
+        Under T1 both values equal ``user_id``; no Redis state is written.
+        Under T2 (after S1-TID-1) a UUID session_id is persisted in Redis and
+        a new one is created when the previous session has ended.
+        """
+        # T1: session collapses to the user identity; no persistence needed.
+        session_id = user_id
+        thread_id = make_thread_id(user_id, session_id)
+        logger.debug("session resolved: user_id=%s session_id=%s thread_id=%s",
+                     user_id, session_id, thread_id)
+        return session_id, thread_id
+
+    async def end_session(self, user_id: str, session_id: str) -> None:
+        """Mark a session as ended.
+
+        No-op under T1.  Under T2 this will delete the Redis session key so
+        the next call to :meth:`get_or_create_session` starts a fresh session.
+        """
+        # T1: nothing to clean up.
+        pass

--- a/telegram_adapter/telegram_bot.py
+++ b/telegram_adapter/telegram_bot.py
@@ -26,6 +26,7 @@ from telegram.ext import Application, CommandHandler, MessageHandler, ContextTyp
 
 from core.exceptions import RedisConnectionError
 from core.message_handler import MessageProcessor, TypingIndicator
+from core.session import SessionManager
 from core.utils import log_error
 from config.bot_config import BotConfig
 from db.user_data import clear_user_data
@@ -184,9 +185,11 @@ class TelegramMessageProcessor(MessageProcessor):
                 user_agent = await agent_manager.get_agent(user_id)
 
                 # Use the user-specific agent
+                session_mgr = SessionManager(self.redis)
+                _session_id, thread_id = await session_mgr.get_or_create_session(user_id)
                 response = await user_agent.ainvoke(
                     {"messages": [{"role": "user", "content": combined}]},
-                    config={"configurable": {"user_id": user_id, "thread_id": user_id}},
+                    config={"configurable": {"user_id": user_id, "thread_id": thread_id}},
                 )
             else:
                 # S1-BOOT-1: AgentManager is required. No shared fallback agent exists.

--- a/tests/test_session_layer.py
+++ b/tests/test_session_layer.py
@@ -1,0 +1,88 @@
+"""
+Tests for core/session.py — session layer as sole producer of thread_id.
+
+These tests use no live Redis; the T1 implementation is stateless.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from core.session import SessionManager, make_thread_id
+
+
+# --------------------------------------------------------------------------- #
+# make_thread_id                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_make_thread_id_t1_equals_user_id():
+    """T1: thread_id must equal user_id regardless of session_id."""
+    assert make_thread_id("user_123", "user_123") == "user_123"
+    assert make_thread_id("user_abc", "some-uuid") == "user_abc"
+
+
+def test_make_thread_id_deterministic():
+    """Same inputs always produce the same thread_id."""
+    assert make_thread_id("u1", "s1") == make_thread_id("u1", "s1")
+
+
+# --------------------------------------------------------------------------- #
+# SessionManager.get_or_create_session                                         #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_get_or_create_returns_tuple():
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    result = await mgr.get_or_create_session("5178700920")
+    assert isinstance(result, tuple) and len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_t1_session_id_equals_user_id():
+    """T1: session_id and thread_id both equal user_id."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    session_id, thread_id = await mgr.get_or_create_session("5178700920")
+    assert session_id == "5178700920"
+    assert thread_id == "5178700920"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_uses_make_thread_id():
+    """thread_id must always be the result of make_thread_id(user_id, session_id)."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    user_id = "u_42"
+    session_id, thread_id = await mgr.get_or_create_session(user_id)
+    assert thread_id == make_thread_id(user_id, session_id)
+
+
+@pytest.mark.asyncio
+async def test_end_session_is_noop_under_t1():
+    """T1: end_session must not raise and must not call Redis."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    await mgr.end_session("user_1", "user_1")
+    redis_mock.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Canonical rule: adapters must not construct thread_id themselves             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_thread_id_source_is_session_manager():
+    """
+    Regression: thread_id must come from SessionManager, not hardcoded in callers.
+
+    This test documents the contract; the actual enforcement is in the
+    telegram_bot.py call site (thread_id is obtained via get_or_create_session).
+    """
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    user_id = "telegram_user_999"
+    _, thread_id = await mgr.get_or_create_session(user_id)
+    # Under T1 this is user_id; under T2 it will be f"{user_id}:{session_id}".
+    # Callers should treat thread_id as opaque — never construct it themselves.
+    assert thread_id is not None
+    assert isinstance(thread_id, str)
+    assert len(thread_id) > 0


### PR DESCRIPTION
## Summary

Closes #21 — establishes `core/session.py` as the **sole producer** of `thread_id`.

## Changes

| File | Change |
|------|--------|
| `core/session.py` | New module: `SessionManager` class + `make_thread_id()` |
| `telegram_adapter/telegram_bot.py` | `process_messages()`: replace bare `"thread_id": user_id` with `SessionManager.get_or_create_session()` |

## What this enforces

- `thread_id` is produced exclusively by `core/session.py`
- Adapters pass only `user_id`; they receive back `(session_id, thread_id)`
- Module-level docstring states the canonical rule

## Prerequisite for S1-TID-1
S1-TID-1 (T2 thread shape) builds on this branch.