### PR TITLE
feat(session): S1-TID-1 — T2 thread_id with Redis session persistence

### DIFF
--- a/core/session.py
+++ b/core/session.py
@@ -1,0 +1,66 @@
+"""
+Session lifecycle management.
+
+This module is the **sole producer** of ``thread_id``.
+Adapters (Telegram, Web UI, future REST/SSE clients) MUST NOT construct
+``thread_id`` themselves — they call :func:`get_or_create_session` and use
+the returned value.
+
+Current mode: T1 — ``thread_id == user_id`` (single conversation per user).
+S1-TID-1 will switch to T2 by changing :func:`make_thread_id` only.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis
+
+logger = logging.getLogger(__name__)
+
+
+def make_thread_id(user_id: str, session_id: str) -> str:
+    """Return the canonical ``thread_id`` for a user + session pair.
+
+    T1 (current): returns ``user_id`` — one persistent thread per user.
+    T2 (S1-TID-1): returns ``f"{user_id}:{session_id}"`` — per-session threads.
+
+    This is the single line that changes when Step 1.5 switches from T1 to T2.
+    """
+    return user_id  # T1 — change to f"{user_id}:{session_id}" in S1-TID-1
+
+
+class SessionManager:
+    """Manages Pantheon session lifecycle.
+
+    The sole authority for ``thread_id`` production.  Adapters pass only
+    ``user_id`` (and optionally adapter-specific metadata); they receive back
+    a ``(session_id, thread_id)`` pair and must not derive either themselves.
+    """
+
+    def __init__(self, redis: "Redis") -> None:
+        self._redis = redis
+
+    async def get_or_create_session(self, user_id: str) -> tuple[str, str]:
+        """Return ``(session_id, thread_id)`` for the user's current session.
+
+        Under T1 both values equal ``user_id``; no Redis state is written.
+        Under T2 (after S1-TID-1) a UUID session_id is persisted in Redis and
+        a new one is created when the previous session has ended.
+        """
+        # T1: session collapses to the user identity; no persistence needed.
+        session_id = user_id
+        thread_id = make_thread_id(user_id, session_id)
+        logger.debug("session resolved: user_id=%s session_id=%s thread_id=%s",
+                     user_id, session_id, thread_id)
+        return session_id, thread_id
+
+    async def end_session(self, user_id: str, session_id: str) -> None:
+        """Mark a session as ended.
+
+        No-op under T1.  Under T2 this will delete the Redis session key so
+        the next call to :meth:`get_or_create_session` starts a fresh session.
+        """
+        # T1: nothing to clean up.
+        pass

--- a/core/session.py
+++ b/core/session.py
@@ -6,12 +6,13 @@ Adapters (Telegram, Web UI, future REST/SSE clients) MUST NOT construct
 ``thread_id`` themselves — they call :func:`get_or_create_session` and use
 the returned value.
 
-Current mode: T1 — ``thread_id == user_id`` (single conversation per user).
-S1-TID-1 will switch to T2 by changing :func:`make_thread_id` only.
+Current mode: T2 — ``thread_id = f"{user_id}:{session_id}"``.
+One UUID session per user; a new session starts after :meth:`end_session` is called.
 """
 from __future__ import annotations
 
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,48 +20,66 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SESSION_KEY_PREFIX = "pantheon:user_session"
+_SESSION_TTL = 86400 * 30  # 30 days
+
 
 def make_thread_id(user_id: str, session_id: str) -> str:
     """Return the canonical ``thread_id`` for a user + session pair.
 
-    T1 (current): returns ``user_id`` — one persistent thread per user.
-    T2 (S1-TID-1): returns ``f"{user_id}:{session_id}"`` — per-session threads.
-
-    This is the single line that changes when Step 1.5 switches from T1 to T2.
+    T2: ``f"{user_id}:{session_id}"`` — per-session threads, multiple
+    conversations per user.
     """
-    return user_id  # T1 — change to f"{user_id}:{session_id}" in S1-TID-1
+    return f"{user_id}:{session_id}"
 
 
 class SessionManager:
     """Manages Pantheon session lifecycle.
 
     The sole authority for ``thread_id`` production.  Adapters pass only
-    ``user_id`` (and optionally adapter-specific metadata); they receive back
-    a ``(session_id, thread_id)`` pair and must not derive either themselves.
+    ``user_id``; they receive back ``(session_id, thread_id)`` and must not
+    derive either themselves.
+
+    Redis key: ``pantheon:user_session:{user_id}`` → current ``session_id`` (UUID string).
+    A new session UUID is generated when none exists (first use or after reset).
     """
 
     def __init__(self, redis: "Redis") -> None:
         self._redis = redis
 
+    def _key(self, user_id: str) -> str:
+        return f"{_SESSION_KEY_PREFIX}:{user_id}"
+
     async def get_or_create_session(self, user_id: str) -> tuple[str, str]:
         """Return ``(session_id, thread_id)`` for the user's current session.
 
-        Under T1 both values equal ``user_id``; no Redis state is written.
-        Under T2 (after S1-TID-1) a UUID session_id is persisted in Redis and
-        a new one is created when the previous session has ended.
+        Reads the current ``session_id`` from Redis.  If none exists, generates
+        a new UUID, persists it, and returns the new pair.
         """
-        # T1: session collapses to the user identity; no persistence needed.
-        session_id = user_id
+        existing = await self._redis.get(self._key(user_id))
+        if existing:
+            session_id = existing if isinstance(existing, str) else existing.decode()
+        else:
+            session_id = str(uuid.uuid4())
+            await self._redis.set(self._key(user_id), session_id, ex=_SESSION_TTL)
+            logger.info("new session created: user_id=%s session_id=%s", user_id, session_id)
+
         thread_id = make_thread_id(user_id, session_id)
         logger.debug("session resolved: user_id=%s session_id=%s thread_id=%s",
                      user_id, session_id, thread_id)
         return session_id, thread_id
 
     async def end_session(self, user_id: str, session_id: str) -> None:
-        """Mark a session as ended.
+        """End the current session so the next interaction starts a fresh one.
 
-        No-op under T1.  Under T2 this will delete the Redis session key so
-        the next call to :meth:`get_or_create_session` starts a fresh session.
+        Deletes the Redis key; the next call to :meth:`get_or_create_session`
+        will generate a new UUID session.
+
+        Called by ``/reset`` after ``clear_user_data`` wipes checkpoint and
+        memory state, ensuring the new conversation starts on a clean thread.
         """
-        # T1: nothing to clean up.
-        pass
+        deleted = await self._redis.delete(self._key(user_id))
+        if deleted:
+            logger.info("session ended: user_id=%s session_id=%s", user_id, session_id)
+        else:
+            logger.debug("end_session: no active session key for user_id=%s", user_id)

--- a/telegram_adapter/telegram_bot.py
+++ b/telegram_adapter/telegram_bot.py
@@ -26,6 +26,7 @@ from telegram.ext import Application, CommandHandler, MessageHandler, ContextTyp
 
 from core.exceptions import RedisConnectionError
 from core.message_handler import MessageProcessor, TypingIndicator
+from core.session import SessionManager
 from core.utils import log_error
 from config.bot_config import BotConfig
 from db.user_data import clear_user_data
@@ -184,9 +185,11 @@ class TelegramMessageProcessor(MessageProcessor):
                 user_agent = await agent_manager.get_agent(user_id)
 
                 # Use the user-specific agent
+                session_mgr = SessionManager(self.redis)
+                _session_id, thread_id = await session_mgr.get_or_create_session(user_id)
                 response = await user_agent.ainvoke(
                     {"messages": [{"role": "user", "content": combined}]},
-                    config={"configurable": {"user_id": user_id, "thread_id": user_id}},
+                    config={"configurable": {"user_id": user_id, "thread_id": thread_id}},
                 )
             else:
                 # S1-BOOT-1: AgentManager is required. No shared fallback agent exists.

--- a/telegram_adapter/telegram_bot.py
+++ b/telegram_adapter/telegram_bot.py
@@ -344,8 +344,14 @@ class TelegramBot:
             return
 
         try:
-            # Clear user data
+            # Clear user data (checkpoints, store, Redis buffers)
             await clear_user_data(user_id, redis, pool, store)
+
+            # End the current session so the next message starts a fresh thread_id
+            from core.session import SessionManager
+            session_mgr = SessionManager(redis)
+            session_id, _ = await session_mgr.get_or_create_session(user_id)
+            await session_mgr.end_session(user_id, session_id)
 
             # Also remove the agent from the agent manager if it exists
             agent_manager = getattr(self.message_processor, 'agent_manager', None)

--- a/tests/test_session_layer.py
+++ b/tests/test_session_layer.py
@@ -1,0 +1,88 @@
+"""
+Tests for core/session.py — session layer as sole producer of thread_id.
+
+These tests use no live Redis; the T1 implementation is stateless.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from core.session import SessionManager, make_thread_id
+
+
+# --------------------------------------------------------------------------- #
+# make_thread_id                                                               #
+# --------------------------------------------------------------------------- #
+
+def test_make_thread_id_t1_equals_user_id():
+    """T1: thread_id must equal user_id regardless of session_id."""
+    assert make_thread_id("user_123", "user_123") == "user_123"
+    assert make_thread_id("user_abc", "some-uuid") == "user_abc"
+
+
+def test_make_thread_id_deterministic():
+    """Same inputs always produce the same thread_id."""
+    assert make_thread_id("u1", "s1") == make_thread_id("u1", "s1")
+
+
+# --------------------------------------------------------------------------- #
+# SessionManager.get_or_create_session                                         #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_get_or_create_returns_tuple():
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    result = await mgr.get_or_create_session("5178700920")
+    assert isinstance(result, tuple) and len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_t1_session_id_equals_user_id():
+    """T1: session_id and thread_id both equal user_id."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    session_id, thread_id = await mgr.get_or_create_session("5178700920")
+    assert session_id == "5178700920"
+    assert thread_id == "5178700920"
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_uses_make_thread_id():
+    """thread_id must always be the result of make_thread_id(user_id, session_id)."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    user_id = "u_42"
+    session_id, thread_id = await mgr.get_or_create_session(user_id)
+    assert thread_id == make_thread_id(user_id, session_id)
+
+
+@pytest.mark.asyncio
+async def test_end_session_is_noop_under_t1():
+    """T1: end_session must not raise and must not call Redis."""
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    await mgr.end_session("user_1", "user_1")
+    redis_mock.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Canonical rule: adapters must not construct thread_id themselves             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_thread_id_source_is_session_manager():
+    """
+    Regression: thread_id must come from SessionManager, not hardcoded in callers.
+
+    This test documents the contract; the actual enforcement is in the
+    telegram_bot.py call site (thread_id is obtained via get_or_create_session).
+    """
+    redis_mock = AsyncMock()
+    mgr = SessionManager(redis_mock)
+    user_id = "telegram_user_999"
+    _, thread_id = await mgr.get_or_create_session(user_id)
+    # Under T1 this is user_id; under T2 it will be f"{user_id}:{session_id}".
+    # Callers should treat thread_id as opaque — never construct it themselves.
+    assert thread_id is not None
+    assert isinstance(thread_id, str)
+    assert len(thread_id) > 0

--- a/tests/test_session_layer.py
+++ b/tests/test_session_layer.py
@@ -1,26 +1,29 @@
 """
 Tests for core/session.py — session layer as sole producer of thread_id.
 
-These tests use no live Redis; the T1 implementation is stateless.
+S1-TID-1: T2 mode — thread_id = f"{user_id}:{session_id}" (UUID-based sessions).
 """
 import pytest
 from unittest.mock import AsyncMock
 
-from core.session import SessionManager, make_thread_id
+from core.session import SessionManager, make_thread_id, _SESSION_KEY_PREFIX
 
 
 # --------------------------------------------------------------------------- #
-# make_thread_id                                                               #
+# make_thread_id — T2                                                          #
 # --------------------------------------------------------------------------- #
 
-def test_make_thread_id_t1_equals_user_id():
-    """T1: thread_id must equal user_id regardless of session_id."""
-    assert make_thread_id("user_123", "user_123") == "user_123"
-    assert make_thread_id("user_abc", "some-uuid") == "user_abc"
+def test_make_thread_id_t2_format():
+    """T2: thread_id must be 'user_id:session_id'."""
+    assert make_thread_id("user_123", "uuid-abc") == "user_123:uuid-abc"
+
+
+def test_make_thread_id_does_not_equal_user_id():
+    """T2: thread_id must NOT be bare user_id (T1 regression guard)."""
+    assert make_thread_id("user_123", "some-uuid") != "user_123"
 
 
 def test_make_thread_id_deterministic():
-    """Same inputs always produce the same thread_id."""
     assert make_thread_id("u1", "s1") == make_thread_id("u1", "s1")
 
 
@@ -29,40 +32,95 @@ def test_make_thread_id_deterministic():
 # --------------------------------------------------------------------------- #
 
 @pytest.mark.asyncio
-async def test_get_or_create_returns_tuple():
+async def test_get_or_create_creates_new_session_when_none_exists():
+    """First call should generate a UUID session_id and persist it in Redis."""
     redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+
     mgr = SessionManager(redis_mock)
-    result = await mgr.get_or_create_session("5178700920")
-    assert isinstance(result, tuple) and len(result) == 2
+    session_id, thread_id = await mgr.get_or_create_session("user_42")
+
+    redis_mock.set.assert_called_once()
+    call_args = redis_mock.set.call_args
+    assert call_args[0][0] == f"{_SESSION_KEY_PREFIX}:user_42"
+    assert call_args[0][1] == session_id
+    assert thread_id == f"user_42:{session_id}"
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_t1_session_id_equals_user_id():
-    """T1: session_id and thread_id both equal user_id."""
+async def test_get_or_create_returns_existing_session():
+    """Subsequent calls return the same session_id from Redis."""
     redis_mock = AsyncMock()
+    redis_mock.get.return_value = b"existing-uuid-1234"
+
     mgr = SessionManager(redis_mock)
-    session_id, thread_id = await mgr.get_or_create_session("5178700920")
-    assert session_id == "5178700920"
-    assert thread_id == "5178700920"
+    session_id, thread_id = await mgr.get_or_create_session("user_42")
+
+    assert session_id == "existing-uuid-1234"
+    assert thread_id == "user_42:existing-uuid-1234"
+    redis_mock.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_handles_str_from_redis():
+    """Redis may return str (decode_responses=True) — must handle both."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = "str-session-id"
+
+    mgr = SessionManager(redis_mock)
+    session_id, _ = await mgr.get_or_create_session("u1")
+    assert session_id == "str-session-id"
 
 
 @pytest.mark.asyncio
 async def test_get_or_create_uses_make_thread_id():
-    """thread_id must always be the result of make_thread_id(user_id, session_id)."""
     redis_mock = AsyncMock()
+    redis_mock.get.return_value = b"fixed-uuid"
+
     mgr = SessionManager(redis_mock)
-    user_id = "u_42"
-    session_id, thread_id = await mgr.get_or_create_session(user_id)
-    assert thread_id == make_thread_id(user_id, session_id)
+    session_id, thread_id = await mgr.get_or_create_session("u99")
+    assert thread_id == make_thread_id("u99", session_id)
+
+
+# --------------------------------------------------------------------------- #
+# SessionManager.end_session                                                   #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_end_session_deletes_redis_key():
+    redis_mock = AsyncMock()
+    redis_mock.delete.return_value = 1
+
+    mgr = SessionManager(redis_mock)
+    await mgr.end_session("user_42", "some-uuid")
+
+    redis_mock.delete.assert_called_once_with(f"{_SESSION_KEY_PREFIX}:user_42")
 
 
 @pytest.mark.asyncio
-async def test_end_session_is_noop_under_t1():
-    """T1: end_session must not raise and must not call Redis."""
+async def test_end_session_noop_when_no_key():
     redis_mock = AsyncMock()
+    redis_mock.delete.return_value = 0
+
     mgr = SessionManager(redis_mock)
-    await mgr.end_session("user_1", "user_1")
-    redis_mock.delete.assert_not_called()
+    await mgr.end_session("user_42", "ghost-session")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_reset_flow_yields_new_session_id():
+    """After end_session, get_or_create_session returns a different session_id."""
+    redis_mock = AsyncMock()
+    redis_mock.get.return_value = None
+    mgr = SessionManager(redis_mock)
+    session_id_1, _ = await mgr.get_or_create_session("user_42")
+
+    redis_mock.delete.return_value = 1
+    await mgr.end_session("user_42", session_id_1)
+
+    redis_mock.get.return_value = None
+    session_id_2, _ = await mgr.get_or_create_session("user_42")
+
+    assert session_id_1 != session_id_2
 
 
 # --------------------------------------------------------------------------- #
@@ -70,19 +128,12 @@ async def test_end_session_is_noop_under_t1():
 # --------------------------------------------------------------------------- #
 
 @pytest.mark.asyncio
-async def test_thread_id_source_is_session_manager():
-    """
-    Regression: thread_id must come from SessionManager, not hardcoded in callers.
-
-    This test documents the contract; the actual enforcement is in the
-    telegram_bot.py call site (thread_id is obtained via get_or_create_session).
-    """
+async def test_thread_id_is_opaque_to_callers():
     redis_mock = AsyncMock()
+    redis_mock.get.return_value = b"opaque-uuid"
+
     mgr = SessionManager(redis_mock)
-    user_id = "telegram_user_999"
-    _, thread_id = await mgr.get_or_create_session(user_id)
-    # Under T1 this is user_id; under T2 it will be f"{user_id}:{session_id}".
-    # Callers should treat thread_id as opaque — never construct it themselves.
-    assert thread_id is not None
-    assert isinstance(thread_id, str)
-    assert len(thread_id) > 0
+    _, thread_id = await mgr.get_or_create_session("telegram_user_999")
+
+    assert isinstance(thread_id, str) and len(thread_id) > 0
+    assert thread_id.startswith("telegram_user_999:")


### PR DESCRIPTION
## Summary

Implements S1-TID-1: switch to T2 `thread_id = f"{user_id}:{session_id}"` with Redis-backed session persistence.

## Changes

| File | Change |
|------|--------|
| `core/session.py` | `make_thread_id()` → T2 format; `get_or_create_session()` with Redis persistence; `end_session()` |
| `telegram_adapter/telegram_bot.py` | `/reset` calls `end_session()` to rotate to fresh thread after data wipe |
| `tests/test_session_layer.py` | 11 tests covering T2 format, Redis persistence, reset flow |

## Test results



## Note
Stacked on `feat/issue-21-session-layer` — merge #21 first, or merge this directly as it contains all #21 changes.

## Closes
Closes S1-TID-1, closes #21