### PR TITLE
feat(auth): S1-AUTH-2 — API-key middleware (SHA-256, /api/v1/* gated)

### DIFF
--- a/api/middleware/__init__.py
+++ b/api/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""Pantheon API middleware package."""

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -1,0 +1,100 @@
+"""
+API-key authentication middleware for Pantheon.
+
+S1-AUTH-2: Validates requests to /api/v1/* endpoints against the
+``api_keys`` table (SHA-256 hash comparison).
+
+Design constraints (Sprint 1):
+- Hash comparison only — no scopes, no last_used_at, no rate limiting
+  (deferred to Sprint 2+, per 001_auth_schema.sql header).
+- Telegram adapter bypasses this middleware (it communicates via internal
+  AgentManager, not the HTTP API).
+- /api/v1/health is exempt (liveness probe).
+
+Usage:
+    app.add_middleware(APIKeyMiddleware, pool=pg_pool)
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from psycopg_pool import AsyncConnectionPool
+
+logger = logging.getLogger(__name__)
+
+# Routes that bypass auth entirely.
+_EXEMPT_PREFIXES = (
+    "/api/v1/health",
+    "/docs",
+    "/openapi.json",
+    "/redoc",
+)
+
+
+def _hash_key(raw_key: str) -> str:
+    """Return SHA-256 hex digest of the raw API key."""
+    return hashlib.sha256(raw_key.encode()).hexdigest()
+
+
+async def _lookup_key(pool: "AsyncConnectionPool", key_hash: str) -> bool:
+    """Return True if *key_hash* exists in the api_keys table."""
+    try:
+        async with pool.connection() as conn:
+            row = await conn.fetchrow(
+                "SELECT id FROM api_keys WHERE key_hash = $1 LIMIT 1",
+                key_hash,
+            )
+            return row is not None
+    except Exception as exc:
+        logger.error("api_key lookup failed: %s", exc)
+        return False
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that enforces API-key auth on /api/v1/* routes.
+
+    Reads the key from the ``X-API-Key`` header.  Requests missing the
+    header, or whose key hash is not in ``api_keys``, receive a 401 response.
+
+    Exempt routes (health probe, docs) bypass the check unconditionally.
+    """
+
+    def __init__(self, app, pool: "AsyncConnectionPool") -> None:
+        super().__init__(app)
+        self._pool = pool
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+
+        # Exempt: health, docs, non-API paths
+        if not path.startswith("/api/v1/") or any(
+            path.startswith(p) for p in _EXEMPT_PREFIXES
+        ):
+            return await call_next(request)
+
+        raw_key = request.headers.get("X-API-Key", "").strip()
+        if not raw_key:
+            logger.warning("auth: missing X-API-Key header path=%s", path)
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Missing X-API-Key header"},
+            )
+
+        key_hash = _hash_key(raw_key)
+        valid = await _lookup_key(self._pool, key_hash)
+        if not valid:
+            logger.warning("auth: invalid API key path=%s hash_prefix=%s", path, key_hash[:8])
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid API key"},
+            )
+
+        logger.debug("auth: accepted path=%s hash_prefix=%s", path, key_hash[:8])
+        return await call_next(request)

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -11,21 +11,22 @@ Design constraints (Sprint 1):
   AgentManager, not the HTTP API).
 - /api/v1/health is exempt (liveness probe).
 
+Pool access:
+    The middleware reads ``request.app.state.pg_pool`` which is set by the
+    lifespan startup handler in ``main.py``.  No constructor injection needed.
+
 Usage:
-    app.add_middleware(APIKeyMiddleware, pool=pg_pool)
+    app.add_middleware(APIKeyMiddleware)
+    # lifespan must set: app.state.pg_pool = pool
 """
 from __future__ import annotations
 
 import hashlib
 import logging
-from typing import TYPE_CHECKING
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
-
-if TYPE_CHECKING:
-    from psycopg_pool import AsyncConnectionPool
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ def _hash_key(raw_key: str) -> str:
     return hashlib.sha256(raw_key.encode()).hexdigest()
 
 
-async def _lookup_key(pool: "AsyncConnectionPool", key_hash: str) -> bool:
+async def _lookup_key(pool, key_hash: str) -> bool:
     """Return True if *key_hash* exists in the api_keys table."""
     try:
         async with pool.connection() as conn:
@@ -63,12 +64,11 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     Reads the key from the ``X-API-Key`` header.  Requests missing the
     header, or whose key hash is not in ``api_keys``, receive a 401 response.
 
+    Pool is read from ``request.app.state.pg_pool``; if the pool is not yet
+    available (before lifespan startup), the middleware fails open with a 503.
+
     Exempt routes (health probe, docs) bypass the check unconditionally.
     """
-
-    def __init__(self, app, pool: "AsyncConnectionPool") -> None:
-        super().__init__(app)
-        self._pool = pool
 
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
@@ -87,10 +87,21 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 content={"detail": "Missing X-API-Key header"},
             )
 
+        pool = getattr(request.app.state, "pg_pool", None)
+        if pool is None:
+            # Startup not complete; fail with 503 rather than 500
+            logger.error("auth: pg_pool not available yet path=%s", path)
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Service starting up — retry shortly"},
+            )
+
         key_hash = _hash_key(raw_key)
-        valid = await _lookup_key(self._pool, key_hash)
+        valid = await _lookup_key(pool, key_hash)
         if not valid:
-            logger.warning("auth: invalid API key path=%s hash_prefix=%s", path, key_hash[:8])
+            logger.warning(
+                "auth: invalid API key path=%s hash_prefix=%s", path, key_hash[:8]
+            )
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Invalid API key"},

--- a/main.py
+++ b/main.py
@@ -170,6 +170,11 @@ app.include_router(sessions_router)
 app.include_router(ws_router)
 app.include_router(models_router)
 
+# S1-AUTH-2: API-key middleware — gates all /api/v1/* routes except /health
+from api.middleware.auth import APIKeyMiddleware  # noqa: E402
+app.add_middleware(APIKeyMiddleware)
+
+
 
 # --------------------------------------------------------------------------- #
 # Application entrypoint                                                       #
@@ -193,6 +198,7 @@ async def main():
 
         # S1-AUTH-1: create tenants / users / api_keys if not exist
         await setup_auth_schema(pool)
+        app.state.pg_pool = pool  # S1-AUTH-2: exposed for APIKeyMiddleware
 
         # Create Redis connection
         logger.info(f"Connecting to Redis at {bot_config.redis_url}")

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -91,7 +91,7 @@ async def test_health_route_is_exempt():
     mw = APIKeyMiddleware(app=MagicMock())
     call_next = AsyncMock(return_value=MagicMock(status_code=200))
     request = _make_request("/api/v1/health")
-    request.headers.get = MagicMock(return_value="")
+    # exempt path — middleware returns before reading headers
 
     await mw.dispatch(request, call_next)
     call_next.assert_called_once()

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,191 @@
+"""Tests for api/middleware/auth.py — S1-AUTH-2 API-key middleware.
+
+All tests use mocked pool and request objects — no live DB required.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.middleware.auth import APIKeyMiddleware, _hash_key, _lookup_key, _EXEMPT_PREFIXES
+
+
+# --------------------------------------------------------------------------- #
+# _hash_key                                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_hash_key_returns_sha256_hex():
+    result = _hash_key("my-secret-key")
+    import hashlib
+    expected = hashlib.sha256(b"my-secret-key").hexdigest()
+    assert result == expected
+
+
+def test_hash_key_is_deterministic():
+    assert _hash_key("abc") == _hash_key("abc")
+
+
+def test_hash_key_differs_for_different_inputs():
+    assert _hash_key("key1") != _hash_key("key2")
+
+
+def test_hash_key_64_chars():
+    """SHA-256 hex digest is always 64 characters."""
+    assert len(_hash_key("anything")) == 64
+
+
+# --------------------------------------------------------------------------- #
+# _lookup_key                                                                  #
+# --------------------------------------------------------------------------- #
+
+async def test_lookup_key_returns_true_when_found():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": "some-uuid"})
+    pool = MagicMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.connection = MagicMock(return_value=cm)
+
+    result = await _lookup_key(pool, "abc123hash")
+    assert result is True
+
+
+async def test_lookup_key_returns_false_when_not_found():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    pool = MagicMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.connection = MagicMock(return_value=cm)
+
+    result = await _lookup_key(pool, "nonexistent")
+    assert result is False
+
+
+async def test_lookup_key_returns_false_on_exception():
+    pool = MagicMock()
+    pool.connection = MagicMock(side_effect=Exception("DB down"))
+
+    result = await _lookup_key(pool, "anyhash")
+    assert result is False
+
+
+# --------------------------------------------------------------------------- #
+# Middleware dispatch — exempt routes                                          #
+# --------------------------------------------------------------------------- #
+
+def _make_request(path: str, headers: dict = None, pool=None):
+    """Build a minimal mock Request."""
+    request = MagicMock()
+    request.url.path = path
+    request.headers = headers or {}
+    request.app.state.pg_pool = pool
+    return request
+
+
+async def test_health_route_is_exempt():
+    """Requests to /api/v1/health must bypass auth unconditionally."""
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+    request = _make_request("/api/v1/health")
+    request.headers.get = MagicMock(return_value="")
+
+    await mw.dispatch(request, call_next)
+    call_next.assert_called_once()
+
+
+async def test_docs_route_is_exempt():
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+    request = _make_request("/docs")
+    await mw.dispatch(request, call_next)
+    call_next.assert_called_once()
+
+
+async def test_non_api_path_is_exempt():
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock(return_value=MagicMock(status_code=200))
+    request = _make_request("/static/logo.png")
+    await mw.dispatch(request, call_next)
+    call_next.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# Middleware dispatch — auth enforcement                                       #
+# --------------------------------------------------------------------------- #
+
+async def test_missing_header_returns_401():
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock()
+    request = _make_request("/api/v1/sessions")
+    request.headers = {"X-API-Key": ""}
+
+    response = await mw.dispatch(request, call_next)
+    assert response.status_code == 401
+    call_next.assert_not_called()
+
+
+async def test_invalid_key_returns_401():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    pool = MagicMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.connection = MagicMock(return_value=cm)
+
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock()
+    request = _make_request("/api/v1/sessions", pool=pool)
+    request.headers = {"X-API-Key": "bad-key"}
+
+    response = await mw.dispatch(request, call_next)
+    assert response.status_code == 401
+    call_next.assert_not_called()
+
+
+async def test_valid_key_calls_next():
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value={"id": "tenant-uuid"})
+    pool = MagicMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=conn)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    pool.connection = MagicMock(return_value=cm)
+
+    mw = APIKeyMiddleware(app=MagicMock())
+    next_response = MagicMock(status_code=202)
+    call_next = AsyncMock(return_value=next_response)
+    request = _make_request("/api/v1/sessions", pool=pool)
+    request.headers = {"X-API-Key": "valid-raw-key"}
+
+    response = await mw.dispatch(request, call_next)
+    assert response.status_code == 202
+    call_next.assert_called_once()
+
+
+async def test_pool_unavailable_returns_503():
+    """Before lifespan startup, pg_pool is None — must return 503, not crash."""
+    mw = APIKeyMiddleware(app=MagicMock())
+    call_next = AsyncMock()
+    request = _make_request("/api/v1/sessions", pool=None)
+    request.headers = {"X-API-Key": "some-key"}
+
+    response = await mw.dispatch(request, call_next)
+    assert response.status_code == 503
+    call_next.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Exempt prefix coverage                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_exempt_prefixes_includes_health():
+    assert "/api/v1/health" in _EXEMPT_PREFIXES
+
+
+def test_exempt_prefixes_includes_docs():
+    assert "/docs" in _EXEMPT_PREFIXES


### PR DESCRIPTION
## Summary

Implements S1-AUTH-2: API-key authentication middleware for all `/api/v1/*` routes.

## Changes

| File | Change |
|------|--------|
| `api/middleware/__init__.py` | New package |
| `api/middleware/auth.py` | `APIKeyMiddleware` — SHA-256 hash comparison against `api_keys` table |
| `main.py` | Register `APIKeyMiddleware`; expose `app.state.pg_pool` in lifespan startup |
| `tests/test_auth_middleware.py` | 16 tests |

## Design

- Middleware reads pool from `request.app.state.pg_pool` (set by lifespan startup)
- Pool unavailable before startup → 503 (not crash)
- Exempt routes: `/api/v1/health`, `/docs`, `/openapi.json`, `/redoc`
- Sprint 1 scope: hash comparison only — scopes, last_used_at, rate limiting deferred to Sprint 2+
- Telegram adapter not affected (communicates via AgentManager, not HTTP)

## Test results

```
tests/test_auth_middleware.py  16/16 passed
```

## Closes
Closes S1-AUTH-2