### PR TITLE
fix(ci): migrate ChatLiteLLM from langchain_community to langchain_litellm

### DIFF
--- a/llm/provider.py
+++ b/llm/provider.py
@@ -3,6 +3,8 @@ Unified LLM provider using LiteLLM for multi-model support.
 
 Supports Claude, GPT, and Gemini through a single interface,
 compatible with LangChain's ChatLiteLLM wrapper for LangGraph integration.
+
+Uses langchain-litellm (standalone package; langchain-community sunset per issue #674).
 """
 
 import logging
@@ -10,7 +12,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from langchain_community.chat_models import ChatLiteLLM
+from langchain_litellm import ChatLiteLLM
 
 logger = logging.getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ langmem
 langchain
 langchain-core
 langchain_community
+langchain-litellm
 asyncpg
 psycopg2-binary
 langchain-openai


### PR DESCRIPTION
## Problem

CI has been red on `main` and all PRs due to:

```
ImportError: cannot import name 'ChatLiteLLM' from 'langchain_community.chat_models'
```

Root cause: `langchain-community` is being sunset ([upstream #674](https://github.com/langchain-ai/langchain-community/issues/674)). `ChatLiteLLM` was removed from it and moved to the standalone `langchain-litellm` package.

## Changes

| File | Change |
|------|--------|
| `llm/provider.py:13` | `from langchain_community.chat_models import ChatLiteLLM` → `from langchain_litellm import ChatLiteLLM` |
| `requirements.txt` | Add `langchain-litellm` |

## Verification

```
tests/test_llm_provider.py  15/15 passed
```

## Merge first

Merge this before or alongside PR #29 to clear CI red on `main`.
This unblocks the entire Sprint 1 PR stack CI status.